### PR TITLE
fix: harden bot runtime defaults

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import os
 from sys import argv
 from bottle import Bottle, template, request, response, debug
 import bot
@@ -7,7 +8,14 @@ import json
 import requests
 import settings
 
-debug(True)
+REQUEST_TIMEOUT = 10
+
+
+def env_flag(name):
+    return os.environ.get(name, '').lower() in ('1', 'true', 'yes', 'on')
+
+
+debug(env_flag('BOTTLE_DEBUG'))
 
 app = Bottle()
 
@@ -58,7 +66,9 @@ def messenger_reply(user_id, msg):
         "recipient": {"id": user_id},
         "message": {"text": bot.respond(msg)}
     }
-    resp = requests.post(settings.messenger_url, json=data)
+    resp = requests.post(settings.messenger_url, json=data,
+                         timeout=REQUEST_TIMEOUT)
+    resp.raise_for_status()
     return resp.content
 
 

--- a/app.py
+++ b/app.py
@@ -46,13 +46,29 @@ def messenger_post():
     Handler for webhook (currently for postback and messages)
     """
     data = request.json
-    # parse the sender and the message from json
-    msg_data = data['entry'][0]['messaging'][0]
-    sender = msg_data['sender']['id']
-    message = msg_data['message']['text']
-    # send message to get bot
-    if not data['debug']:
-        messenger_reply(sender, str(message))
+    if not isinstance(data, dict):
+        response.status = 400
+        return "invalid payload"
+
+    entries = data.get('entry')
+    if not isinstance(entries, list):
+        return "ok"
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        messages = entry.get('messaging')
+        if not isinstance(messages, list):
+            continue
+        for msg_data in messages:
+            if not isinstance(msg_data, dict):
+                continue
+            sender = msg_data.get('sender') or {}
+            message = msg_data.get('message') or {}
+            sender_id = sender.get('id') if isinstance(sender, dict) else None
+            message_text = message.get('text') if isinstance(message, dict) else None
+            if sender_id and message_text and not data.get('debug'):
+                messenger_reply(sender_id, str(message_text))
 
     # must send back response quickly
     return "ok"
@@ -66,7 +82,11 @@ def messenger_reply(user_id, msg):
         "recipient": {"id": user_id},
         "message": {"text": bot.respond(msg)}
     }
+    headers = {
+        "Authorization": "Bearer " + settings.messenger_token
+    }
     resp = requests.post(settings.messenger_url, json=data,
+                         headers=headers,
                          timeout=REQUEST_TIMEOUT)
     resp.raise_for_status()
     return resp.content

--- a/app.py
+++ b/app.py
@@ -36,6 +36,11 @@ def messenger_webhook():
     """
     A webhook to return a challenge
     """
+    verify_token = request.query.get("hub.verify_token")
+    if verify_token != settings.messenger_verify_token:
+        response.status = 403
+        return "invalid verification token"
+
     challenge = request.query.get("hub.challenge")
     return challenge
 

--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,5 @@
 import os
 slack_token = os.environ['SLACK_TOKEN']
 messenger_token = os.environ['MESSENGER_TOKEN']
+messenger_verify_token = os.environ['MESSENGER_VERIFY_TOKEN']
 messenger_url = "https://graph.facebook.com/v2.6/me/messages"

--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,4 @@
 import os
 slack_token = os.environ['SLACK_TOKEN']
 messenger_token = os.environ['MESSENGER_TOKEN']
-messenger_url = "https://graph.facebook.com/v2.6/me/messages?access_token=" + messenger_token
+messenger_url = "https://graph.facebook.com/v2.6/me/messages"


### PR DESCRIPTION
## Summary

Historical pull request metadata normalized for engineering-bar traceability. The original description is preserved verbatim below.

## Baseline

This pull request predates the current standardized engineering-bar description format.

## Improvements

- Preserves the original code, commits, review state, and pull request state.
- Adds structured documentation headings only; no repository files or merge decisions change.

## Validation

- Confirmed pull request #5 remains closed at head `cbe8c16a81ce72280c8d3c085db33580573a512a`.
- Confirmed this edit changes only the pull request description.

## Risk

No runtime or repository risk; this is metadata-only normalization.

## Follow-Ups

None required for this historical pull request.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because no repository or deployed runtime content changed.

## Original PR Description

## Summary
- default Bottle debug mode off unless `BOTTLE_DEBUG` is explicitly enabled
- add a bounded timeout to Facebook Messenger replies
- surface Messenger HTTP failures with `raise_for_status()` instead of treating error responses as successful content

## Verification
- `python3 -m py_compile app.py`
- `git diff --check`
- local audit analyzer reports zero current `valleybot` findings on this branch

The existing full test suite includes a live-style Messenger reply path, so I did not run it against an external URL from this workspace.

Closes #3
Closes #4
