### PR TITLE
fix: ignore Messenger echo messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   moderation fallback and runtime regression coverage.
 - See `docs/plans/2026-06-12-messenger-json-content-type.md` for the exact JSON
   media-type requirement on signed Messenger webhook requests.
+- See `docs/plans/2026-06-13-messenger-echo-guard.md` for ignoring page echo
+  messages without hiding later user messages in the same webhook payload.
 
 ## Contributing
 

--- a/app.py
+++ b/app.py
@@ -179,6 +179,8 @@ def parse_messenger_message(data):
                 continue
             sender = event.get('sender') or {}
             message = event.get('message') or {}
+            if message.get('is_echo') is True:
+                continue
             sender_id = sender.get('id')
             message_text = message.get('text')
             try:

--- a/bot_tests.py
+++ b/bot_tests.py
@@ -206,6 +206,44 @@ class TestFacebook(unittest.TestCase):
         r = self.post_signed_json(data)
         self.assertEqual(r.status_int, 200)
 
+    def test_facebook_echo_message_is_ignored(self):
+        calls = []
+        original_reply = app.messenger_reply
+        app.messenger_reply = lambda sender, message: calls.append(
+            (sender, message))
+        data = {'object': 'page',
+                'entry': [{'messaging': [{
+                    'sender': {'id': self.user_id},
+                    'message': {'text': 'page reply', 'is_echo': True}
+                }]}]}
+        try:
+            r = self.post_signed_json(data)
+        finally:
+            app.messenger_reply = original_reply
+
+        self.assertEqual(r.status_int, 200)
+        self.assertEqual(calls, [])
+
+    def test_facebook_echo_does_not_hide_later_user_message(self):
+        calls = []
+        original_reply = app.messenger_reply
+        app.messenger_reply = lambda sender, message: calls.append(
+            (sender, message))
+        data = {'object': 'page',
+                'entry': [{'messaging': [
+                    {'sender': {'id': self.user_id},
+                     'message': {'text': 'page reply', 'is_echo': True}},
+                    {'sender': {'id': 'user-2'},
+                     'message': {'text': 'real user message'}}
+                ]}]}
+        try:
+            r = self.post_signed_json(data)
+        finally:
+            app.messenger_reply = original_reply
+
+        self.assertEqual(r.status_int, 200)
+        self.assertEqual(calls, [('user-2', 'real user message')])
+
     def test_facebook_webhook_rejects_invalid_signature(self):
         body = json.dumps(self.data).encode('utf-8')
         r = test_app.post(

--- a/docs/plans/2026-06-13-messenger-echo-guard.md
+++ b/docs/plans/2026-06-13-messenger-echo-guard.md
@@ -1,0 +1,30 @@
+# Messenger Echo Guard
+
+Status: Completed
+
+## Context
+
+Messenger can deliver messages sent by the page itself with
+`message.is_echo` set to `true`. The current parser treats those events as
+user messages, which can send another reply and create a reply loop. An echo
+event can also appear before a valid user message in the same payload.
+
+## Plan
+
+1. Ignore Messenger message events explicitly marked as echoes.
+2. Continue scanning the payload so a later valid user message is handled.
+3. Add dependency-free and Bottle/WebTest regression coverage.
+4. Preserve signature, content-type, body-size, page-object, sender, and text
+   validation for normal Messenger messages.
+
+## Verification
+
+- The 36 dependency-free contracts passed, including an echo followed by a
+  valid user message and a non-boolean echo flag.
+- All 25 Bottle/WebTest and bot tests passed, including a pure echo and an echo
+  before a later valid message.
+- The full `make check` gate passed under an isolated Python 3.12 environment
+  with all 18 pinned packages installed.
+- Three hostile mutations were rejected: removing the guard, returning early
+  after an echo, and accepting arbitrary truthy echo values.
+- Python compilation and `git diff --check` passed.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -58,6 +58,9 @@ FILTER_FALLBACK_PLAN_PATH = (
 MESSENGER_CONTENT_TYPE_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-12-messenger-json-content-type.md"
 )
+MESSENGER_ECHO_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-13-messenger-echo-guard.md"
+)
 
 
 class FakeBottle:
@@ -228,6 +231,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(WEBHOOK_SIZE_PLAN_PATH, "Messenger webhook size limit")
     assert_completed_plan(FILTER_FALLBACK_PLAN_PATH, "filtered response fallback")
     assert_completed_plan(MESSENGER_CONTENT_TYPE_PLAN_PATH, "Messenger JSON content type")
+    assert_completed_plan(MESSENGER_ECHO_PLAN_PATH, "Messenger echo guard")
 
 
 def test_runtime_and_ci_contracts():
@@ -420,6 +424,57 @@ def test_messenger_post_ignores_non_message_events():
 
     assert_equal(body, "ok", "non-message event response")
     assert_equal(requests.calls, [], "non-message events must not call messenger reply")
+
+
+def test_messenger_post_ignores_echoes_and_continues_scanning():
+    app, request, response, requests = load_app()
+    request.json = {
+        "object": "page",
+        "entry": [{
+            "messaging": [
+                {
+                    "sender": {"id": "page-1"},
+                    "message": {"text": "page reply", "is_echo": True}
+                },
+                {
+                    "sender": {"id": "user-1"},
+                    "message": {"text": "hello from user"}
+                }
+            ]
+        }]
+    }
+    response.status = 200
+
+    body = app.messenger_post()
+
+    assert_equal(body, "ok", "Messenger echo event response")
+    assert_equal(len(requests.calls), 1, "only the user message should trigger a reply")
+    _url, kwargs = requests.calls[0]
+    assert_equal(kwargs["json"]["recipient"]["id"], "user-1", "post-echo sender")
+    assert_equal(
+        kwargs["json"]["message"]["text"],
+        "bot: hello from user",
+        "post-echo message",
+    )
+
+
+def test_messenger_post_requires_boolean_true_echo_flag():
+    app, request, response, requests = load_app()
+    request.json = {
+        "object": "page",
+        "entry": [{
+            "messaging": [{
+                "sender": {"id": "user-1"},
+                "message": {"text": "hello", "is_echo": "false"}
+            }]
+        }]
+    }
+    response.status = 200
+
+    body = app.messenger_post()
+
+    assert_equal(body, "ok", "non-boolean echo flag response")
+    assert_equal(len(requests.calls), 1, "non-boolean echo flag reply count")
 
 
 def test_messenger_post_ignores_non_text_or_blank_messages():
@@ -764,6 +819,8 @@ def main():
         test_messenger_verification_requires_matching_token,
         test_messenger_verification_accepts_matching_token,
         test_messenger_post_ignores_non_message_events,
+        test_messenger_post_ignores_echoes_and_continues_scanning,
+        test_messenger_post_requires_boolean_true_echo_flag,
         test_messenger_post_ignores_non_text_or_blank_messages,
         test_messenger_post_trims_sender_and_message_text_before_reply,
         test_messenger_post_rejects_invalid_json_shape,


### PR DESCRIPTION
## Summary

Historical pull request metadata normalized for engineering-bar traceability. The original description is preserved verbatim below.

## Baseline

This pull request predates the current standardized engineering-bar description format.

## Improvements

- Preserves the original code, commits, review state, and pull request state.
- Adds structured documentation headings only; no repository files or merge decisions change.

## Validation

- Confirmed pull request #12 remains closed at head `8830da3bf1b582d7a38eea6fed8c888761a08cc9`.
- Confirmed this edit changes only the pull request description.

## Risk

No runtime or repository risk; this is metadata-only normalization.

## Follow-Ups

None required for this historical pull request.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because no repository or deployed runtime content changed.

## Original PR Description

## Summary

- ignore Messenger events explicitly marked with boolean `is_echo: true`
- continue scanning for a later valid user message in the same payload
- add dependency-free and Bottle/WebTest regression coverage plus completed plan evidence

## Verification

- `make check PYTHON=/tmp/engineering-bar/valleybot-venv/bin/python`
- external-directory `make -f /home/gjones/code/private/worktrees/valleybot-messenger-echo-guard/Makefile check PYTHON=/tmp/engineering-bar/valleybot-venv/bin/python`
- 36 dependency-free contracts
- 25 runtime tests
- 3 hostile mutations rejected
- `git diff --check`

