### PR TITLE
Suppress replayed Messenger messages

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Run repository checks
         run: make check PYTHON=python
       - name: Verify external working directory
-        run: cd "$(mktemp -d)" && make -f "$GITHUB_WORKSPACE/Makefile" check PYTHON=python
+        run: cd "$(mktemp -d)" && make -C "$GITHUB_WORKSPACE" check PYTHON=python

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## 2026-06-13
+
+- Added a bounded, thread-safe recent Messenger message-ID cache to suppress
+  duplicate replies from retried webhook deliveries.
+- Released replay claims after outbound exceptions and preserved messages without
+  usable IDs, debug payloads, echo filtering, and first-message semantics.
+- Made external-directory checks safe for repository paths containing spaces by
+  selecting the repository with GNU Make's `-C` option.
+
 ## 2026-06-12
 
 - Required an exact `application/json` media type for Messenger POST webhooks,

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON ?= python3
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+ROOT := $(CURDIR)
 
 PYTHON_FILES := \
 	app.py \
@@ -13,7 +13,7 @@ PYTHON_FILES := \
 .PHONY: clean lint prepare-corpora test build verify check
 
 check: clean verify
-	$(MAKE) -f "$(ROOT)/Makefile" clean
+	$(MAKE) -C "$(ROOT)" clean
 
 clean:
 	find "$(ROOT)" -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete

--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   JSON request validation, bot conversation log privacy, plus request timeout
   parsing checks. Slack command text, Messenger webhook object type, Messenger
   webhook text, and Messenger sender IDs must be valid before response
-  generation. Messenger POST bodies larger than 1 MiB are rejected with HTTP
+  generation. Recent Messenger message IDs are claimed in a bounded in-memory
+  cache so provider retries do not send duplicate replies; outbound exceptions
+  release their claim for recovery. Messenger POST bodies larger than 1 MiB are rejected with HTTP
   413 before signature verification or JSON parsing. Generated responses that
   fail moderation use a reviewed generic fallback instead of failing a request.
 - `make check` runs `make verify` with bytecode cleanup before and after.
-  The Makefile resolves repository paths explicitly, so the same gate can run
-  from an external working directory.
+  The Makefile uses make's selected directory as the repository root, so the
+  same gate can run from an external working directory with `make -C`.
 - `make prepare-corpora` installs the current TextBlob tokenizer and tagger
   data into the existing project-local `nltk_data` directory. Heroku runs the
   same step through `bin/post_compile`.
@@ -76,6 +78,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   verification from outside the repository directory.
 - Completed maintenance plans live under `docs/plans` and are checked by
   `make check`.
+- See `docs/plans/2026-06-13-messenger-message-replay-guard.md` for the bounded
+  process-local Messenger retry guard.
 - `python -m unittest bot_tests` runs the real Bottle/WebTest and bot suite.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,10 @@ verification, JSON parsing, response generation, or outbound API calls.
 Messenger POST requests must use the `application/json` media type; optional
 parameters and case differences are accepted, while other types return 415
 before signature verification or JSON parsing.
+Recent non-empty Messenger message IDs are claimed before outbound replies in a
+bounded process-local cache. Duplicate deliveries are acknowledged without a
+second reply, and outbound exceptions release their claim. This protection
+does not span multiple workers or process restarts.
 
 For web services, APIs, sockets, or scraping workflows, prioritize reports involving authentication bypass, authorization errors, injection, server-side request forgery, unsafe deserialization, credential leakage, data exposure, or denial-of-service conditions. Use test accounts and minimal proof-of-concept traffic only.
 

--- a/VISION.md
+++ b/VISION.md
@@ -24,6 +24,8 @@ Priority:
 - Reject blank or non-text channel commands before response generation
 - Reject non-page Messenger webhook payloads before event parsing
 - Reject blank or non-text Messenger messages before response generation
+- Suppress duplicate Messenger replies from retried message IDs with bounded
+  process-local state
 - Reject empty web chat queries before response generation
 - Render web chat replies as text instead of concatenated HTML
 - Reject malformed low-level bot JSON requests before response generation

--- a/app.py
+++ b/app.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from sys import argv
+from collections import OrderedDict
 import os
+import threading
 from bottle import Bottle, template, request, response, debug
 import bot
 import hmac
@@ -14,6 +16,31 @@ debug(os.environ.get("BOTTLE_DEBUG", "").strip().lower() == "true")
 
 app = Bottle()
 MAX_MESSENGER_WEBHOOK_BYTES = 1024 * 1024
+MAX_RECENT_MESSENGER_MESSAGE_IDS = 1024
+
+
+class RecentMessageIds(object):
+    def __init__(self, max_entries):
+        self.max_entries = max_entries
+        self._ids = OrderedDict()
+        self._lock = threading.Lock()
+
+    def claim(self, message_id):
+        with self._lock:
+            if message_id in self._ids:
+                return False
+            self._ids[message_id] = None
+            while len(self._ids) > self.max_entries:
+                self._ids.popitem(last=False)
+            return True
+
+    def release(self, message_id):
+        with self._lock:
+            self._ids.pop(message_id, None)
+
+
+recent_messenger_message_ids = RecentMessageIds(
+    MAX_RECENT_MESSENGER_MESSAGE_IDS)
 
 
 # SLACK INTEGRATION
@@ -89,13 +116,20 @@ def messenger_post():
         response.status = 400
         return "invalid payload"
 
-    sender, message = parse_messenger_message(data)
+    sender, message, message_id = parse_messenger_message(data)
     if not (sender and message):
         return "ok"
 
     # send message to get bot
     if not data.get('debug'):
-        messenger_reply(sender, message)
+        if message_id and not recent_messenger_message_ids.claim(message_id):
+            return "ok"
+        try:
+            messenger_reply(sender, message)
+        except Exception:
+            if message_id:
+                recent_messenger_message_ids.release(message_id)
+            raise
 
     # must send back response quickly
     return "ok"
@@ -162,11 +196,11 @@ def clean_text_value(value):
 
 def parse_messenger_message(data):
     """
-    Return the first sender/text pair from a Messenger payload if present.
+    Return the first sender/text/message-ID tuple from a Messenger payload.
     """
     entries = data.get('entry')
     if not isinstance(entries, list):
-        return None, None
+        return None, None, None
 
     for entry in entries:
         if not isinstance(entry, dict):
@@ -183,15 +217,20 @@ def parse_messenger_message(data):
                 continue
             sender_id = sender.get('id')
             message_text = message.get('text')
+            message_id = message.get('mid')
             try:
                 sender_id = sender_id.strip()
                 message_text = message_text.strip()
             except AttributeError:
                 continue
+            try:
+                message_id = message_id.strip()
+            except AttributeError:
+                message_id = None
             if sender_id and message_text:
-                return sender_id, message_text
+                return sender_id, message_text, message_id or None
 
-    return None, None
+    return None, None, None
 
 
 def messenger_reply(user_id, msg):

--- a/docs/plans/2026-06-13-messenger-message-replay-guard.md
+++ b/docs/plans/2026-06-13-messenger-message-replay-guard.md
@@ -1,6 +1,6 @@
 # Messenger Message Replay Guard
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -24,18 +24,25 @@ bot response and repeat downstream work.
   eviction, failure release, malformed IDs, and no-ID compatibility.
 - R7. Document that process-local replay protection is not shared across
   workers or restarts.
+- R8. Keep the complete gate runnable from external working directories when
+  the repository path contains spaces.
 
 ## Scope Boundaries
 
 - Do not add persistence, a distributed cache, dependencies, background jobs,
   or multi-message batch replies.
 - Do not perform a live Messenger webhook or credentialed Graph API request.
+- The Makefile and CI workflow may change only as needed to preserve the
+  existing external-directory contract for paths containing spaces.
 
 ## Verification
 
-- Focused replay tests and full `make check`
-- External-directory and space-containing-path `make check`
-- Hostile mutations for ID parsing, claim ordering, duplicate suppression,
-  bounded eviction, failure release, and plan status
+- Six focused replay tests passed for suppression, no-ID and malformed-ID
+  compatibility, bounded eviction, exception release, and source ordering.
+- Full local, external-directory, and space-containing-path `make check` runs
+  cover dependency-free contracts and the Bottle/WebTest runtime suite.
+- Nine hostile mutations were rejected for ID parsing, duplicate suppression,
+  bounded eviction, cache locking, exception release, plan status, root
+  selection, external CI invocation, and recursive cleanup.
 - Python syntax, workflow YAML, `git diff --check`, generated-artifact, and
-  focused secret review
+  focused secret reviews are included in final validation.

--- a/docs/plans/2026-06-13-messenger-message-replay-guard.md
+++ b/docs/plans/2026-06-13-messenger-message-replay-guard.md
@@ -1,0 +1,41 @@
+# Messenger Message Replay Guard
+
+## Status: In Progress
+
+## Context
+
+Messenger webhook deliveries can be retried with the same message ID. The app
+currently ignores `message.mid`, so a retry can produce a duplicate outbound
+bot response and repeat downstream work.
+
+## Requirements
+
+- R1. Parse a trimmed non-empty Messenger message ID with the existing first
+  valid non-echo text message.
+- R2. Claim IDs before outbound reply work so concurrent or sequential retries
+  do not send duplicate replies.
+- R3. Keep claims in a bounded, process-local, thread-safe recent-ID cache with
+  a fixed maximum size and no attacker-controlled unbounded growth.
+- R4. Release a claim when outbound reply work raises so a provider retry can
+  recover from transient failure.
+- R5. Preserve messages without IDs, debug payload behavior, echo filtering,
+  signature validation, body limits, and first-valid-message semantics.
+- R6. Add runtime and dependency-free coverage for replay suppression, bounded
+  eviction, failure release, malformed IDs, and no-ID compatibility.
+- R7. Document that process-local replay protection is not shared across
+  workers or restarts.
+
+## Scope Boundaries
+
+- Do not add persistence, a distributed cache, dependencies, background jobs,
+  or multi-message batch replies.
+- Do not perform a live Messenger webhook or credentialed Graph API request.
+
+## Verification
+
+- Focused replay tests and full `make check`
+- External-directory and space-containing-path `make check`
+- Hostile mutations for ID parsing, claim ordering, duplicate suppression,
+  bounded eviction, failure release, and plan status
+- Python syntax, workflow YAML, `git diff --check`, generated-artifact, and
+  focused secret review

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -61,6 +61,9 @@ MESSENGER_CONTENT_TYPE_PLAN_PATH = (
 MESSENGER_ECHO_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-13-messenger-echo-guard.md"
 )
+MESSENGER_REPLAY_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-13-messenger-message-replay-guard.md"
+)
 
 
 class FakeBottle:
@@ -232,6 +235,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(FILTER_FALLBACK_PLAN_PATH, "filtered response fallback")
     assert_completed_plan(MESSENGER_CONTENT_TYPE_PLAN_PATH, "Messenger JSON content type")
     assert_completed_plan(MESSENGER_ECHO_PLAN_PATH, "Messenger echo guard")
+    assert_completed_plan(MESSENGER_REPLAY_PLAN_PATH, "Messenger replay guard")
 
 
 def test_runtime_and_ci_contracts():
@@ -262,7 +266,7 @@ def test_runtime_and_ci_contracts():
             "persist-credentials: false",
             "python -m pip install -r requirements.txt",
             "make check PYTHON=python",
-            'make -f "$GITHUB_WORKSPACE/Makefile" check PYTHON=python'):
+            'make -C "$GITHUB_WORKSPACE" check PYTHON=python'):
         assert_true(contract in workflow, "missing CI contract {0}".format(contract))
     assert_true("@v" not in workflow, "CI actions must use immutable commits")
     assert_true("ubuntu-latest" not in workflow, "CI must not use a floating Ubuntu runner")
@@ -301,10 +305,10 @@ def test_runtime_and_ci_contracts():
         assert_true(security_contract in security, "SECURITY.md must document {0}".format(security_contract))
 
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
-    assert_true("ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile, "Makefile must resolve the repository root")
+    assert_true("ROOT := $(CURDIR)" in makefile, "Makefile must use make's selected working directory as the repository root")
     assert_true('find "$(ROOT)"' in makefile, "Makefile cleanup must stay inside the repository")
     assert_true('"$(ROOT)/scripts/check_valleybot_contracts.py"' in makefile, "Makefile must use the rooted contract path")
-    assert_true('$(MAKE) -f "$(ROOT)/Makefile" clean' in makefile, "recursive cleanup must use the repository Makefile")
+    assert_true('$(MAKE) -C "$(ROOT)" clean' in makefile, "recursive cleanup must select the repository directory")
 
     app_source = (ROOT / "app.py").read_text(encoding="utf-8")
     runtime_tests = (ROOT / "bot_tests.py").read_text(encoding="utf-8")
@@ -551,6 +555,101 @@ def test_messenger_post_rejects_non_page_object():
     assert_equal(response.status, 400, "non-page Messenger object status")
     assert_true(body != "ok", "non-page Messenger objects must not be acknowledged as valid")
     assert_equal(requests.calls, [], "non-page Messenger objects must not call messenger reply")
+
+
+def messenger_payload(message_id="mid-1"):
+    message = {"text": "hello from messenger"}
+    if message_id is not None:
+        message["mid"] = message_id
+    return {
+        "object": "page",
+        "entry": [{
+            "messaging": [{
+                "sender": {"id": "user-1"},
+                "message": message,
+            }]
+        }]
+    }
+
+
+def test_messenger_post_suppresses_replayed_message_ids():
+    app, request, _response, requests = load_app()
+    request.json = messenger_payload("mid-replayed")
+
+    assert_equal(app.messenger_post(), "ok", "first Messenger delivery")
+    assert_equal(app.messenger_post(), "ok", "replayed Messenger delivery")
+
+    assert_equal(len(requests.calls), 1, "replayed message ID must send one reply")
+
+
+def test_messenger_post_preserves_messages_without_ids():
+    app, request, _response, requests = load_app()
+    request.json = messenger_payload(None)
+
+    app.messenger_post()
+    app.messenger_post()
+
+    assert_equal(len(requests.calls), 2, "messages without IDs must preserve compatibility")
+
+
+def test_recent_message_ids_evicts_oldest_claims_at_bound():
+    app, _request, _response, _requests = load_app()
+    recent = app.RecentMessageIds(2)
+
+    assert_true(recent.claim("mid-1"), "first replay claim")
+    assert_true(recent.claim("mid-2"), "second replay claim")
+    assert_true(recent.claim("mid-3"), "third replay claim")
+    assert_true(not recent.claim("mid-3"), "newest replay claim must remain protected")
+    assert_true(recent.claim("mid-1"), "oldest replay claim must be evicted")
+
+
+def test_messenger_post_releases_claim_when_reply_fails():
+    app, request, _response, _requests = load_app()
+    request.json = messenger_payload("mid-retry")
+    reply_calls = []
+
+    def failing_reply(sender, message):
+        reply_calls.append((sender, message))
+        raise RuntimeError("provider unavailable")
+
+    app.messenger_reply = failing_reply
+    try:
+        app.messenger_post()
+        raise AssertionError("failed Messenger replies must propagate")
+    except RuntimeError:
+        pass
+
+    app.messenger_reply = lambda sender, message: reply_calls.append((sender, message))
+    assert_equal(app.messenger_post(), "ok", "retry after Messenger reply failure")
+    assert_equal(len(reply_calls), 2, "failed claim must be released for retry")
+
+
+def test_messenger_post_ignores_malformed_message_ids_for_compatibility():
+    app, request, _response, requests = load_app()
+    request.json = messenger_payload({"not": "text"})
+
+    app.messenger_post()
+    app.messenger_post()
+
+    assert_equal(len(requests.calls), 2, "malformed IDs must not suppress valid text messages")
+
+
+def test_messenger_replay_source_contracts():
+    source = (ROOT / "app.py").read_text(encoding="utf-8")
+    for contract in (
+            "MAX_RECENT_MESSENGER_MESSAGE_IDS = 1024",
+            "class RecentMessageIds(object):",
+            "self._lock = threading.Lock()",
+            "self._ids.popitem(last=False)",
+            "message_id = message.get('mid')",
+            "recent_messenger_message_ids.claim(message_id)",
+            "recent_messenger_message_ids.release(message_id)"):
+        assert_true(contract in source, "missing Messenger replay contract {0}".format(contract))
+
+    claim_position = source.index("recent_messenger_message_ids.claim(message_id)")
+    reply_position = source.index("messenger_reply(sender, message)")
+    release_position = source.index("recent_messenger_message_ids.release(message_id)")
+    assert_true(claim_position < reply_position < release_position, "claim, reply, and failure release must stay ordered")
 
 
 def test_messenger_reply_uses_header_auth_and_timeout():
@@ -825,6 +924,12 @@ def main():
         test_messenger_post_trims_sender_and_message_text_before_reply,
         test_messenger_post_rejects_invalid_json_shape,
         test_messenger_post_rejects_non_page_object,
+        test_messenger_post_suppresses_replayed_message_ids,
+        test_messenger_post_preserves_messages_without_ids,
+        test_recent_message_ids_evicts_oldest_claims_at_bound,
+        test_messenger_post_releases_claim_when_reply_fails,
+        test_messenger_post_ignores_malformed_message_ids_for_compatibility,
+        test_messenger_replay_source_contracts,
         test_messenger_reply_uses_header_auth_and_timeout,
         test_request_timeout_accepts_positive_float_env,
         test_request_timeout_defaults_for_invalid_env,


### PR DESCRIPTION
## Summary

Historical pull request metadata normalized for engineering-bar traceability. The original description is preserved verbatim below.

## Baseline

This pull request predates the current standardized engineering-bar description format.

## Improvements

- Preserves the original code, commits, review state, and pull request state.
- Adds structured documentation headings only; no repository files or merge decisions change.

## Validation

- Confirmed pull request #13 remains closed at head `d877656a50d1920604af79143765a0a2c19fad2a`.
- Confirmed this edit changes only the pull request description.

## Risk

No runtime or repository risk; this is metadata-only normalization.

## Follow-Ups

None required for this historical pull request.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because no repository or deployed runtime content changed.

## Original PR Description

## Summary

- claim non-empty Messenger message IDs before outbound reply work
- suppress sequential and concurrent retry deliveries with a bounded, locked process-local cache
- release claims when outbound reply work raises so later retries can recover
- preserve no-ID, malformed-ID, debug, echo-filtering, and first-valid-message behavior
- make the external-directory check portable to repository paths containing spaces

## Verification

- `make check PYTHON=/tmp/engineering-bar/valleybot-venv/bin/python`
- external-directory `make -C` full gate
- copied repository path containing spaces full gate
- 42 dependency-free contract tests and 25 Bottle/WebTest runtime tests
- six focused replay tests
- nine hostile mutations rejected
- workflow YAML parse, Python syntax, `git diff --check`, artifact review, and focused secret review

## Limits

Replay claims are intentionally process-local and bounded. They do not coordinate across workers or survive process restarts.

