### PR TITLE
fix: bound Messenger batch processing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,12 @@
 
 ## 2026-06-13
 
+- Processed up to 20 valid Messenger user messages per signed webhook in payload
+  order while preserving per-message replay claims and failure release.
 - Added a bounded, thread-safe recent Messenger message-ID cache to suppress
   duplicate replies from retried webhook deliveries.
 - Released replay claims after outbound exceptions and preserved messages without
-  usable IDs, debug payloads, echo filtering, and first-message semantics.
+  usable IDs, debug payloads, and echo filtering.
 - Made external-directory checks safe for repository paths containing spaces by
   selecting the repository with GNU Make's `-C` option.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   webhook text, and Messenger sender IDs must be valid before response
   generation. Recent Messenger message IDs are claimed in a bounded in-memory
   cache so provider retries do not send duplicate replies; outbound exceptions
-  release their claim for recovery. Messenger POST bodies larger than 1 MiB are rejected with HTTP
+  release their claim for recovery. Signed webhook batches process up to 20
+  valid user messages in payload order. Messenger POST bodies larger than 1 MiB are rejected with HTTP
   413 before signature verification or JSON parsing. Generated responses that
   fail moderation use a reviewed generic fallback instead of failing a request.
 - `make check` runs `make verify` with bytecode cleanup before and after.
@@ -80,6 +81,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   `make check`.
 - See `docs/plans/2026-06-13-messenger-message-replay-guard.md` for the bounded
   process-local Messenger retry guard.
+- See `docs/plans/2026-06-13-messenger-batch-processing-bound.md` for ordered,
+  capped multi-message webhook processing.
 - `python -m unittest bot_tests` runs the real Bottle/WebTest and bot suite.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,9 @@ Recent non-empty Messenger message IDs are claimed before outbound replies in a
 bounded process-local cache. Duplicate deliveries are acknowledged without a
 second reply, and outbound exceptions release their claim. This protection
 does not span multiple workers or process restarts.
+Each signed webhook processes at most 20 valid user messages in payload order,
+limiting outbound reply amplification while preserving per-message replay
+claims and failure release.
 
 For web services, APIs, sockets, or scraping workflows, prioritize reports involving authentication bypass, authorization errors, injection, server-side request forgery, unsafe deserialization, credential leakage, data exposure, or denial-of-service conditions. Use test accounts and minimal proof-of-concept traffic only.
 

--- a/VISION.md
+++ b/VISION.md
@@ -26,6 +26,7 @@ Priority:
 - Reject blank or non-text Messenger messages before response generation
 - Suppress duplicate Messenger replies from retried message IDs with bounded
   process-local state
+- Process Messenger message batches in order with a fixed per-webhook cap
 - Reject empty web chat queries before response generation
 - Render web chat replies as text instead of concatenated HTML
 - Reject malformed low-level bot JSON requests before response generation

--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ debug(os.environ.get("BOTTLE_DEBUG", "").strip().lower() == "true")
 app = Bottle()
 MAX_MESSENGER_WEBHOOK_BYTES = 1024 * 1024
 MAX_RECENT_MESSENGER_MESSAGE_IDS = 1024
+MAX_MESSENGER_MESSAGES_PER_WEBHOOK = 20
 
 
 class RecentMessageIds(object):
@@ -116,20 +117,21 @@ def messenger_post():
         response.status = 400
         return "invalid payload"
 
-    sender, message, message_id = parse_messenger_message(data)
-    if not (sender and message):
+    messages = parse_messenger_messages(data)
+    if not messages:
         return "ok"
 
     # send message to get bot
     if not data.get('debug'):
-        if message_id and not recent_messenger_message_ids.claim(message_id):
-            return "ok"
-        try:
-            messenger_reply(sender, message)
-        except Exception:
-            if message_id:
-                recent_messenger_message_ids.release(message_id)
-            raise
+        for sender, message, message_id in messages:
+            if message_id and not recent_messenger_message_ids.claim(message_id):
+                continue
+            try:
+                messenger_reply(sender, message)
+            except Exception:
+                if message_id:
+                    recent_messenger_message_ids.release(message_id)
+                raise
 
     # must send back response quickly
     return "ok"
@@ -194,14 +196,15 @@ def clean_text_value(value):
     return value or None
 
 
-def parse_messenger_message(data):
+def parse_messenger_messages(data):
     """
-    Return the first sender/text/message-ID tuple from a Messenger payload.
+    Return a bounded list of sender/text/message-ID tuples in payload order.
     """
     entries = data.get('entry')
     if not isinstance(entries, list):
-        return None, None, None
+        return []
 
+    messages = []
     for entry in entries:
         if not isinstance(entry, dict):
             continue
@@ -211,8 +214,10 @@ def parse_messenger_message(data):
         for event in events:
             if not isinstance(event, dict):
                 continue
-            sender = event.get('sender') or {}
-            message = event.get('message') or {}
+            sender = event.get('sender')
+            message = event.get('message')
+            if not isinstance(sender, dict) or not isinstance(message, dict):
+                continue
             if message.get('is_echo') is True:
                 continue
             sender_id = sender.get('id')
@@ -228,9 +233,11 @@ def parse_messenger_message(data):
             except AttributeError:
                 message_id = None
             if sender_id and message_text:
-                return sender_id, message_text, message_id or None
+                messages.append((sender_id, message_text, message_id or None))
+                if len(messages) >= MAX_MESSENGER_MESSAGES_PER_WEBHOOK:
+                    return messages
 
-    return None, None, None
+    return messages
 
 
 def messenger_reply(user_id, msg):

--- a/bot_tests.py
+++ b/bot_tests.py
@@ -244,6 +244,58 @@ class TestFacebook(unittest.TestCase):
         self.assertEqual(r.status_int, 200)
         self.assertEqual(calls, [('user-2', 'real user message')])
 
+    def test_facebook_webhook_replies_to_valid_messages_in_order(self):
+        calls = []
+        original_reply = app.messenger_reply
+        app.messenger_reply = lambda sender, message: calls.append(
+            (sender, message))
+        data = {'object': 'page',
+                'entry': [
+                    {'messaging': [
+                        {'sender': {'id': 'user-1'},
+                         'message': {'text': 'first', 'mid': 'batch-runtime-1'}},
+                        {'sender': {'id': 'page'},
+                         'message': {'text': 'echo', 'is_echo': True}},
+                        {'sender': ['malformed'],
+                         'message': {'text': 'ignored'}},
+                    ]},
+                    {'messaging': [
+                        {'sender': {'id': 'ignored'},
+                         'message': ['malformed']},
+                        {'sender': {'id': 'user-2'},
+                         'message': {'text': 'second', 'mid': 'batch-runtime-2'}}
+                    ]}
+                ]}
+        try:
+            r = self.post_signed_json(data)
+        finally:
+            app.messenger_reply = original_reply
+
+        self.assertEqual(r.status_int, 200)
+        self.assertEqual(calls, [('user-1', 'first'), ('user-2', 'second')])
+
+    def test_facebook_webhook_caps_valid_message_batch(self):
+        calls = []
+        original_reply = app.messenger_reply
+        app.messenger_reply = lambda sender, message: calls.append(
+            (sender, message))
+        events = [
+            {'sender': {'id': 'user-{0}'.format(index)},
+             'message': {'text': 'message-{0}'.format(index),
+                         'mid': 'batch-cap-runtime-{0}'.format(index)}}
+            for index in range(app.MAX_MESSENGER_MESSAGES_PER_WEBHOOK + 1)
+        ]
+        try:
+            r = self.post_signed_json(
+                {'object': 'page', 'entry': [{'messaging': events}]})
+        finally:
+            app.messenger_reply = original_reply
+
+        self.assertEqual(r.status_int, 200)
+        self.assertEqual(len(calls), app.MAX_MESSENGER_MESSAGES_PER_WEBHOOK)
+        self.assertEqual(calls[0], ('user-0', 'message-0'))
+        self.assertEqual(calls[-1], ('user-19', 'message-19'))
+
     def test_facebook_webhook_rejects_invalid_signature(self):
         body = json.dumps(self.data).encode('utf-8')
         r = test_app.post(

--- a/docs/plans/2026-06-13-messenger-batch-processing-bound.md
+++ b/docs/plans/2026-06-13-messenger-batch-processing-bound.md
@@ -1,0 +1,85 @@
+---
+title: "fix: Bound Messenger batch processing"
+type: fix
+date: 2026-06-13
+---
+
+# Bound Messenger Batch Processing
+
+## Status: Planned
+
+## Context
+
+Messenger webhook payloads can contain multiple entries and messaging events,
+but the parser currently returns only the first valid user message. Later valid
+messages are silently acknowledged without a reply. Processing every event
+without a bound would create response-amplification risk, so batch support must
+pair ordered iteration with an explicit per-request maximum.
+
+## Requirements
+
+- R1. Extract valid user messages across all entry and messaging arrays in
+  payload order.
+- R2. Ignore malformed events, delivery/read events, and only boolean-true echo
+  messages without hiding later valid messages.
+- R3. Return no more than 20 valid messages from one webhook payload.
+- R4. Reply to each extracted message in order unless debug mode suppresses
+  outbound requests.
+- R5. Preserve replay claims per message ID and release only the failing
+  message's claim when its outbound reply raises.
+- R6. Continue processing messages without usable IDs without adding replay
+  claims.
+- R7. Add dependency-free and Bottle/WebTest coverage plus mutation-sensitive
+  contracts for ordering, bounds, echo traversal, replay behavior,
+  documentation, and completed-plan status.
+
+## Implementation Units
+
+### U1. Extract a bounded message batch
+
+- **Files:** `app.py`
+- Replace first-message return semantics with a list of sender/text/message-ID
+  tuples capped by a named constant.
+- Preserve text/sender trimming, optional message-ID cleanup, and existing
+  malformed-event handling.
+
+### U2. Process each message independently
+
+- **Files:** `app.py`
+- Iterate the bounded list in payload order.
+- Apply replay claim, outbound reply, and exception-release handling per
+  message so one retry does not duplicate earlier successful replies.
+
+### U3. Prove batch and failure semantics
+
+- **Files:** `bot_tests.py`, `scripts/check_valleybot_contracts.py`
+- Cover ordered multi-message replies, the 20-message cap, echoes before/between
+  messages, replayed IDs within a batch, ID-less messages, debug suppression,
+  and release of only the failing claim.
+- Preserve existing signature, media-type, size, and object validation tests.
+
+### U4. Record the operational boundary
+
+- **Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- Document ordered bounded processing and the intentionally process-local replay
+  cache.
+
+## Verification
+
+- Run focused dependency-free and Bottle/WebTest Messenger batch tests, then
+  local and external-working-directory `make check` under explicit timeouts.
+- Reject hostile mutations for first-message regression, removed cap, wrong
+  ordering, echo short-circuiting, shared replay handling, missing claim
+  release, weakened tests, documentation drift, and stale plan status.
+- Validate Python syntax, workflow YAML, dependency audit, intended paths,
+  generated artifacts, whitespace, conflict markers, and changed-line secret
+  patterns.
+- Use no live Messenger credentials or provider requests; outbound calls remain
+  replaced with deterministic fakes in validation.
+
+## Scope Boundaries
+
+- Do not add background queues, parallel replies, distributed replay storage,
+  retries, new dependencies, or provider API changes.
+- Do not process more than 20 valid messages from one webhook request.
+- Do not merge or close any pull request without explicit owner authorization.

--- a/docs/plans/2026-06-13-messenger-batch-processing-bound.md
+++ b/docs/plans/2026-06-13-messenger-batch-processing-bound.md
@@ -6,7 +6,7 @@ date: 2026-06-13
 
 # Bound Messenger Batch Processing
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -66,16 +66,35 @@ pair ordered iteration with an explicit per-request maximum.
 
 ## Verification
 
-- Run focused dependency-free and Bottle/WebTest Messenger batch tests, then
-  local and external-working-directory `make check` under explicit timeouts.
-- Reject hostile mutations for first-message regression, removed cap, wrong
-  ordering, echo short-circuiting, shared replay handling, missing claim
-  release, weakened tests, documentation drift, and stale plan status.
-- Validate Python syntax, workflow YAML, dependency audit, intended paths,
-  generated artifacts, whitespace, conflict markers, and changed-line secret
-  patterns.
-- Use no live Messenger credentials or provider requests; outbound calls remain
-  replaced with deterministic fakes in validation.
+- Six focused dependency-free batch tests passed for ordered replies, the
+  per-webhook cap, replay suppression, ID-less compatibility, debug
+  suppression, and failing-claim isolation.
+- Two focused Bottle/WebTest batch tests passed in an isolated Python 3.12
+  environment after the documented corpus preparation.
+- The pre-completion dependency-free gate passed 48 tests and the full runtime
+  suite passed 27 tests.
+- Fifteen hostile mutations covering first-message regression, cap removal,
+  malformed nested event acceptance, echo acceptance, replay short-circuiting,
+  missing claim release, missing runtime tests, documentation drift, and stale
+  plan status were rejected.
+- `uv pip check` passed for all 18 installed packages. Pinned
+  `pip-audit==2.10.0` reported no known vulnerabilities in `requirements.txt`;
+  it explicitly skipped the pinned `webob==1.6.1.1070258` distribution because
+  that distribution was not found on public PyPI.
+- Final local and external-working-directory `make check` runs passed with the
+  same isolated pinned interpreter under explicit five-minute timeouts after
+  this completed-plan record was written.
+- No live Messenger credential or provider request was used; outbound calls
+  remained deterministic fakes.
+
+## Work Completed
+
+- Replaced first-message parsing with ordered extraction of up to 20 valid
+  sender/text/message-ID tuples across all entries and messaging arrays.
+- Applied replay claims, replies, and exception release independently for each
+  extracted message while preserving ID-less and debug compatibility.
+- Added dependency-free and Bottle/WebTest coverage for ordering, limits,
+  echoes, replayed IDs, ID-less messages, debug payloads, and failure isolation.
 
 ## Scope Boundaries
 

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -64,6 +64,9 @@ MESSENGER_ECHO_PLAN_PATH = (
 MESSENGER_REPLAY_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-13-messenger-message-replay-guard.md"
 )
+MESSENGER_BATCH_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-13-messenger-batch-processing-bound.md"
+)
 
 
 class FakeBottle:
@@ -236,6 +239,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_CONTENT_TYPE_PLAN_PATH, "Messenger JSON content type")
     assert_completed_plan(MESSENGER_ECHO_PLAN_PATH, "Messenger echo guard")
     assert_completed_plan(MESSENGER_REPLAY_PLAN_PATH, "Messenger replay guard")
+    assert_completed_plan(MESSENGER_BATCH_PLAN_PATH, "Messenger batch processing bound")
 
 
 def test_runtime_and_ci_contracts():
@@ -572,6 +576,126 @@ def messenger_payload(message_id="mid-1"):
     }
 
 
+def messenger_batch_payload(events, debug=False):
+    payload = {
+        "object": "page",
+        "entry": [{"messaging": events}],
+    }
+    if debug:
+        payload["debug"] = True
+    return payload
+
+
+def messenger_event(sender, text, message_id=None, is_echo=False):
+    message = {"text": text}
+    if message_id is not None:
+        message["mid"] = message_id
+    if is_echo:
+        message["is_echo"] = True
+    return {"sender": {"id": sender}, "message": message}
+
+
+def test_messenger_post_processes_valid_batch_in_payload_order():
+    app, request, _response, requests = load_app()
+    request.json = messenger_batch_payload([
+        messenger_event("user-1", "first", "mid-batch-1"),
+        messenger_event("page", "echo", "mid-echo", is_echo=True),
+        {"sender": ["malformed"], "message": {"text": "ignored"}},
+        {"sender": {"id": "ignored"}, "message": ["malformed"]},
+        messenger_event("user-2", "second", "mid-batch-2"),
+    ])
+
+    assert_equal(app.messenger_post(), "ok", "ordered Messenger batch response")
+    assert_equal(len(requests.calls), 2, "ordered Messenger batch reply count")
+    assert_equal(
+        [call[1]["json"]["recipient"]["id"] for call in requests.calls],
+        ["user-1", "user-2"],
+        "ordered Messenger batch recipients",
+    )
+
+
+def test_messenger_post_caps_valid_batch():
+    app, request, _response, requests = load_app()
+    request.json = messenger_batch_payload([
+        messenger_event(
+            "user-{0}".format(index),
+            "message-{0}".format(index),
+            "mid-cap-{0}".format(index),
+        )
+        for index in range(app.MAX_MESSENGER_MESSAGES_PER_WEBHOOK + 1)
+    ])
+
+    assert_equal(app.messenger_post(), "ok", "capped Messenger batch response")
+    assert_equal(
+        len(requests.calls),
+        app.MAX_MESSENGER_MESSAGES_PER_WEBHOOK,
+        "capped Messenger batch reply count",
+    )
+    assert_equal(
+        requests.calls[-1][1]["json"]["recipient"]["id"],
+        "user-19",
+        "capped Messenger batch final recipient",
+    )
+
+
+def test_messenger_post_applies_replay_claims_per_batch_message():
+    app, request, _response, requests = load_app()
+    request.json = messenger_batch_payload([
+        messenger_event("user-1", "first", "mid-same"),
+        messenger_event("user-2", "duplicate", "mid-same"),
+        messenger_event("user-3", "without id"),
+    ])
+
+    app.messenger_post()
+
+    assert_equal(len(requests.calls), 2, "batch replay and ID-less reply count")
+    assert_equal(
+        [call[1]["json"]["recipient"]["id"] for call in requests.calls],
+        ["user-1", "user-3"],
+        "batch replay and ID-less recipients",
+    )
+
+
+def test_messenger_post_debug_batch_suppresses_all_replies():
+    app, request, _response, requests = load_app()
+    request.json = messenger_batch_payload([
+        messenger_event("user-1", "first", "mid-debug-1"),
+        messenger_event("user-2", "second", "mid-debug-2"),
+    ], debug=True)
+
+    app.messenger_post()
+
+    assert_equal(requests.calls, [], "debug Messenger batch replies")
+
+
+def test_messenger_post_releases_only_failing_batch_claim():
+    app, request, _response, _requests = load_app()
+    request.json = messenger_batch_payload([
+        messenger_event("user-1", "first", "mid-success"),
+        messenger_event("user-2", "second", "mid-failure"),
+    ])
+
+    def fail_second(sender, _message):
+        if sender == "user-2":
+            raise RuntimeError("provider unavailable")
+
+    app.messenger_reply = fail_second
+    try:
+        app.messenger_post()
+        raise AssertionError("failed batch reply must propagate")
+    except RuntimeError:
+        pass
+
+    assert_true(
+        not app.recent_messenger_message_ids.claim("mid-success"),
+        "successful earlier batch claim must remain protected",
+    )
+    assert_true(
+        app.recent_messenger_message_ids.claim("mid-failure"),
+        "failing batch claim must be released",
+    )
+
+
 def test_messenger_post_suppresses_replayed_message_ids():
     app, request, _response, requests = load_app()
     request.json = messenger_payload("mid-replayed")
@@ -650,6 +774,50 @@ def test_messenger_replay_source_contracts():
     reply_position = source.index("messenger_reply(sender, message)")
     release_position = source.index("recent_messenger_message_ids.release(message_id)")
     assert_true(claim_position < reply_position < release_position, "claim, reply, and failure release must stay ordered")
+
+
+def test_messenger_batch_source_contracts():
+    source = (ROOT / "app.py").read_text(encoding="utf-8")
+    runtime_tests = (ROOT / "bot_tests.py").read_text(encoding="utf-8")
+    for contract in (
+            "MAX_MESSENGER_MESSAGES_PER_WEBHOOK = 20",
+            "messages = parse_messenger_messages(data)",
+            "for sender, message, message_id in messages:",
+            "if not isinstance(sender, dict) or not isinstance(message, dict):",
+            "messages.append((sender_id, message_text, message_id or None))",
+            "if len(messages) >= MAX_MESSENGER_MESSAGES_PER_WEBHOOK:",
+            "return messages"):
+        assert_true(contract in source, "missing Messenger batch contract {0}".format(contract))
+    assert_true(
+        "return sender_id, message_text, message_id or None" not in source,
+        "Messenger parser must not regress to first-message return semantics",
+    )
+    for test_name in (
+            "test_facebook_webhook_replies_to_valid_messages_in_order",
+            "test_facebook_webhook_caps_valid_message_batch"):
+        assert_true(test_name in runtime_tests, "missing Bottle/WebTest batch coverage {0}".format(test_name))
+
+    parse_position = source.index("messages = parse_messenger_messages(data)")
+    loop_position = source.index("for sender, message, message_id in messages:")
+    claim_position = source.index("recent_messenger_message_ids.claim(message_id)", loop_position)
+    reply_position = source.index("messenger_reply(sender, message)", loop_position)
+    release_position = source.index("recent_messenger_message_ids.release(message_id)", loop_position)
+    assert_true(
+        parse_position < loop_position < claim_position < reply_position < release_position,
+        "bounded extraction and per-message claim, reply, and release must stay ordered",
+    )
+
+    docs = {
+        "README.md": "Signed webhook batches process up to 20",
+        "SECURITY.md": "Each signed webhook processes at most 20",
+        "VISION.md": "Process Messenger message batches in order",
+        "CHANGES.md": "Processed up to 20 valid Messenger user messages",
+    }
+    for relative_path, phrase in docs.items():
+        assert_true(
+            phrase in (ROOT / relative_path).read_text(encoding="utf-8"),
+            "{0} must document bounded Messenger batches".format(relative_path),
+        )
 
 
 def test_messenger_reply_uses_header_auth_and_timeout():
@@ -924,12 +1092,18 @@ def main():
         test_messenger_post_trims_sender_and_message_text_before_reply,
         test_messenger_post_rejects_invalid_json_shape,
         test_messenger_post_rejects_non_page_object,
+        test_messenger_post_processes_valid_batch_in_payload_order,
+        test_messenger_post_caps_valid_batch,
+        test_messenger_post_applies_replay_claims_per_batch_message,
+        test_messenger_post_debug_batch_suppresses_all_replies,
+        test_messenger_post_releases_only_failing_batch_claim,
         test_messenger_post_suppresses_replayed_message_ids,
         test_messenger_post_preserves_messages_without_ids,
         test_recent_message_ids_evicts_oldest_claims_at_bound,
         test_messenger_post_releases_claim_when_reply_fails,
         test_messenger_post_ignores_malformed_message_ids_for_compatibility,
         test_messenger_replay_source_contracts,
+        test_messenger_batch_source_contracts,
         test_messenger_reply_uses_header_auth_and_timeout,
         test_request_timeout_accepts_positive_float_env,
         test_request_timeout_defaults_for_invalid_env,


### PR DESCRIPTION
## Summary

Historical pull request metadata normalized for engineering-bar traceability. The original description is preserved verbatim below.

## Baseline

This pull request predates the current standardized engineering-bar description format.

## Improvements

- Preserves the original code, commits, review state, and pull request state.
- Adds structured documentation headings only; no repository files or merge decisions change.

## Validation

- Confirmed pull request #14 remains closed at head `22234f995b13db0231d487f18e7110d064ca6b59`.
- Confirmed this edit changes only the pull request description.

## Risk

No runtime or repository risk; this is metadata-only normalization.

## Follow-Ups

None required for this historical pull request.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because no repository or deployed runtime content changed.

## Original PR Description

## Summary

Messenger webhook deliveries can now process every valid user message in payload order instead of silently acknowledging all but the first. Processing is capped at 20 replies per signed webhook, while malformed events, echoes, and replayed message IDs are skipped without hiding later valid messages.

Replay claims remain independent per message: earlier successful replies stay protected, and only a claim whose outbound request fails is released for retry. The replay cache remains intentionally bounded and process-local.

## Verification

- `timeout 300s make check PYTHON=/tmp/valleybot-batch-venv/bin/python`
- external-working-directory `make check` under the same five-minute timeout
- 48 dependency-free contract checks and 27 Bottle/WebTest runtime tests
- 15 hostile batch-processing mutations rejected
- `uv pip check` passed for 18 installed packages
- `pip-audit==2.10.0 -r requirements.txt` found no known vulnerabilities; the pinned non-PyPI WebOb distribution was explicitly skipped
- no high-confidence credentials in added lines; no untracked or generated artifacts

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)

