### PR TITLE
fix: protect Make root from overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON ?= python3
-ROOT := $(CURDIR)
+override ROOT := $(CURDIR)
 
 PYTHON_FILES := \
 	app.py \

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,6 +1,6 @@
 # Protect the Selected Make Repository Root
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -32,3 +32,22 @@ recursive cleanup outside that selected checkout.
 - Do not change runtime behavior, packages, NLTK corpora, workflows, or
   Messenger security policy.
 - Do not merge or close stacked pull requests without owner authorization.
+
+## Work Completed
+
+- Protected the selected Make working directory with `override` while
+  preserving the Python command and recursive cleanup behavior.
+- Added exact-line checker contracts and registered this completed plan.
+
+## Verification
+
+- Python compilation and the focused runtime/CI contract passed.
+- Local, external-directory, and hostile-root `make check` runs passed under
+  360-second timeouts with 48 dependency-free contracts and 27 runtime tests.
+- Eight valid hostile root, checker, Python override, cleanup-routing, and
+  plan-status mutations were rejected.
+- `uv pip check` passed for all 18 installed packages. `pip-audit` reported no
+  known vulnerabilities in the unchanged direct requirements and explicitly
+  skipped the pinned non-PyPI WebOb distribution.
+- Python syntax, workflow YAML, SVG XML, intended-path, generated-corpus,
+  `git diff --check`, and changed-line secret audits passed.

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,0 +1,34 @@
+# Protect the Selected Make Repository Root
+
+## Status: Planned
+
+## Context
+
+Valleybot intentionally treats GNU Make's selected working directory as the
+repository root so `make -C <checkout>` remains portable. A command-line
+`ROOT=` assignment can still redirect compilation, tests, contracts, and
+recursive cleanup outside that selected checkout.
+
+## Requirements
+
+- Protect `ROOT := $(CURDIR)` with GNU Make's `override` directive.
+- Preserve `PYTHON ?= python3`, recursive cleanup, and the pinned package gate.
+- Require the exact protected root and Python lines in the dependency-free
+  checker.
+- Pass local, external-directory, and hostile-root full gates.
+- Reject weakened root, checker, Python override, cleanup, and plan mutations.
+- Preserve Messenger behavior, dependencies, workflows, and test coverage.
+
+## Verification Plan
+
+- focused runtime/CI contract and Python compilation
+- bounded local, external-directory, and hostile-root `make check`
+- focused hostile mutations
+- pinned dependency integrity/audit, workflow YAML, SVG XML, artifact,
+  whitespace, and changed-line secret audits
+
+## Scope Boundaries
+
+- Do not change runtime behavior, packages, NLTK corpora, workflows, or
+  Messenger security policy.
+- Do not merge or close stacked pull requests without owner authorization.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -67,6 +67,9 @@ MESSENGER_REPLAY_PLAN_PATH = (
 MESSENGER_BATCH_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-13-messenger-batch-processing-bound.md"
 )
+MAKE_ROOT_PROTECTION_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-14-make-root-override-protection.md"
+)
 
 
 class FakeBottle:
@@ -240,6 +243,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_ECHO_PLAN_PATH, "Messenger echo guard")
     assert_completed_plan(MESSENGER_REPLAY_PLAN_PATH, "Messenger replay guard")
     assert_completed_plan(MESSENGER_BATCH_PLAN_PATH, "Messenger batch processing bound")
+    assert_completed_plan(MAKE_ROOT_PROTECTION_PLAN_PATH, "Make root override protection")
 
 
 def test_runtime_and_ci_contracts():
@@ -309,7 +313,9 @@ def test_runtime_and_ci_contracts():
         assert_true(security_contract in security, "SECURITY.md must document {0}".format(security_contract))
 
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
-    assert_true("ROOT := $(CURDIR)" in makefile, "Makefile must use make's selected working directory as the repository root")
+    makefile_lines = set(makefile.splitlines())
+    assert_true("override ROOT := $(CURDIR)" in makefile_lines, "Makefile must protect make's selected working directory as the repository root")
+    assert_true("PYTHON ?= python3" in makefile_lines, "Makefile must preserve the Python command override")
     assert_true('find "$(ROOT)"' in makefile, "Makefile cleanup must stay inside the repository")
     assert_true('"$(ROOT)/scripts/check_valleybot_contracts.py"' in makefile, "Makefile must use the rooted contract path")
     assert_true('$(MAKE) -C "$(ROOT)" clean' in makefile, "recursive cleanup must select the repository directory")


### PR DESCRIPTION
## Summary

Historical pull request metadata normalized for engineering-bar traceability. The original description is preserved verbatim below.

## Baseline

This pull request predates the current standardized engineering-bar description format.

## Improvements

- Preserves the original code, commits, review state, and pull request state.
- Adds structured documentation headings only; no repository files or merge decisions change.

## Validation

- Confirmed pull request #15 remains closed at head `923faf1e5282cad669c20746ed9e2ec7b90502ee`.
- Confirmed this edit changes only the pull request description.

## Risk

No runtime or repository risk; this is metadata-only normalization.

## Follow-Ups

None required for this historical pull request.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because no repository or deployed runtime content changed.

## Original PR Description

## Summary

Valleybot verification and recursive cleanup can no longer be redirected outside the checkout selected by `make -C`. The protected `CURDIR` root preserves external invocation portability, the configurable Python command, and the full pinned package gate.

## Test Plan

- local, external-directory, and hostile-root full gates
- 48 dependency-free contracts and 27 runtime tests per gate
- eight valid focused mutations
- `uv pip check`, `pip-audit`, YAML/XML, artifact, whitespace, and secret audits

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

