### PR TITLE
docs: add moderation review guide

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-14
+
+- Added a mandatory human moderation checklist for response templates, blocked
+  terms, reviewed fallbacks, regression boundaries, channel consistency,
+  synthetic fixtures, reviewer evidence, and unresolved concerns.
+
 ## 2026-06-13
 
 - Processed up to 20 valid Messenger user messages per signed webhook in payload

--- a/MODERATION.md
+++ b/MODERATION.md
@@ -1,0 +1,48 @@
+# Moderation And Content Review
+
+Valleybot is a historical stereotype-based chatbot. Every change to response
+templates, blocked terms, or fallback text requires human content review before
+merge. The prefix filter in `bot.filter_response` is a narrow final-output
+guard, not a complete moderation system.
+
+## Review Scope
+
+Review every added, removed, or changed value in these sources:
+
+- response templates and fallback text in `config.py`
+- response construction and filtering in `bot.py`
+- channel adapters that deliver generated text
+- moderation fixtures and expected output in tests
+
+Review the text in context, including substitutions and prefixes that can turn
+an otherwise neutral template into harmful output.
+
+## Harm Checklist
+
+Check for slurs, profanity, harassment, protected-class stereotypes, sexual
+content, threats, self-harm language, and demeaning identity language. Also
+consider combinations of accepted fragments, misspellings, capitalization,
+punctuation, and prefix matches.
+
+For every blocked-term addition or removal, record the rationale and affected
+examples. Do not remove a term solely to make a generated response pass.
+
+## Required Verification
+
+1. Add accepted-boundary and rejected-boundary regression fixtures.
+2. Prove blocked generated text reaches `safe_response` and returns only a
+   reviewed value from `config.NONE_RESPONSES`.
+3. Verify the same response boundary protects web, Slack, Messenger, terminal,
+   and low-level JSON entry points.
+4. Run `make check` and record the result.
+5. Record reviewer, review date, changed content scope, commands, and unresolved
+   concerns in the pull request or completed plan evidence.
+
+Fixtures must be synthetic. Never add real conversation transcripts, user
+identifiers, channel tokens, webhook payloads, or other private data.
+
+## Review Boundary
+
+Automated tests can prove routing and known-term behavior, but they cannot prove
+that generated content is broadly appropriate. Human review remains required,
+and unresolved harmful-content concerns block merge.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 ## Security and Privacy Notes
 
+- See `MODERATION.md` for the mandatory human review checklist covering
+  response templates, blocked terms, fallbacks, regression fixtures, channel
+  consistency, private-data exclusions, and review evidence.
+
 - Review changes touching authentication or token handling; examples from the scan include nltk_data/corpora/movie_reviews/neg/cv000_29416.txt, nltk_data/corpora/movie_reviews/neg/cv067_21192.txt, nltk_data/corpora/movie_reviews/neg/cv074_7188.txt, nltk_data/corpora/movie_reviews/neg/cv144_5010.txt, and 3 more.
 - Review changes touching network requests, sockets, or service endpoints; examples from the scan include app.json, app.py, docs/bugs/p2-python-http-call-without-timeout-a07c6a4bb0ee865f.md, nltk_data/corpora/conll2000/test.txt, and 5 more.
 - Review changes touching file, media, JSON, XML, CSV, OCR, or data parsing; examples from the scan include app.json, app.py, bot.py, bot_tests.py, and 6 more.
@@ -140,6 +144,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   unauthenticated request-body limit.
 - See `docs/plans/2026-06-10-filtered-response-fallback.md` for the completed
   moderation fallback and runtime regression coverage.
+- See `docs/plans/2026-06-14-moderation-review-guide.md` for the human content
+  review and evidence contract.
 - See `docs/plans/2026-06-12-messenger-json-content-type.md` for the exact JSON
   media-type requirement on signed Messenger webhook requests.
 - See `docs/plans/2026-06-13-messenger-echo-guard.md` for ignoring page echo

--- a/VISION.md
+++ b/VISION.md
@@ -37,10 +37,11 @@ Priority:
 - Keep the dependency-free `make check` baseline running in GitHub Actions
 - Return reviewed fallback text when a generated response fails moderation
 - Avoid expanding stereotype content without review
+- Require auditable human review of response templates, blocked terms,
+  fallbacks, fixtures, channel consistency, privacy, and unresolved concerns
 
 Next priorities:
 
-- Add clearer moderation and content-review guidance
 - Document Python version and NLTK/TextBlob setup
 - Separate deployment packaging from bot behavior changes
 

--- a/docs/plans/2026-06-14-moderation-review-guide.md
+++ b/docs/plans/2026-06-14-moderation-review-guide.md
@@ -1,6 +1,6 @@
 # Moderation And Content Review Guide
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -34,11 +34,13 @@ terminal entry points.
 
 ## Verification
 
-- focused moderation-guide and filter/fallback contracts
-- repository and external-directory `make check`
-- hostile review-scope, harmful-category, rationale, fallback, fixture,
-  privacy, evidence, roadmap, suite, and plan-status mutations
-- final artifact, credential, exact-diff, and hosted verification audits
+- Focused moderation-guide and filter/fallback contracts passed.
+- The repository and external-directory `make check` passed.
+- Ten hostile moderation-guide mutations were rejected across review scope,
+  harmful categories, rationale, fallback, fixtures, channels, privacy,
+  reviewer evidence, roadmap, and plan-status contracts.
+- Final artifact, credential, and exact-diff audits passed. Hosted verification
+  is recorded against the exact pull-request head after push.
 
 ## Scope Boundary
 

--- a/docs/plans/2026-06-14-moderation-review-guide.md
+++ b/docs/plans/2026-06-14-moderation-review-guide.md
@@ -1,0 +1,47 @@
+# Moderation And Content Review Guide
+
+## Status: Planned
+
+## Context
+
+Valleybot intentionally generates stereotype-based responses and protects all
+channels with a prefix content filter plus reviewed generic fallbacks. The
+repository does not yet define how a contributor should review additions to
+response templates, filter terms, or fallback text.
+
+## Priority
+
+Add an auditable human-review checklist that keeps content changes explicit,
+testable, privacy-preserving, and consistent across web, Slack, Messenger, and
+terminal entry points.
+
+## Requirements
+
+- Require reviewers to inspect every added or changed response template and
+  blocked term in context.
+- Require review for slurs, profanity, harassment, protected-class stereotypes,
+  sexual content, threats, self-harm, and demeaning identity language.
+- Require a documented rationale for filter additions and removals.
+- Preserve the reviewed generic fallback and verify blocked generated text does
+  not escape through any channel.
+- Require regression fixtures for both accepted and rejected boundaries.
+- Prohibit real conversation transcripts, user identifiers, tokens, or private
+  payloads in review fixtures.
+- Record reviewer, date, scope, commands, and unresolved concerns in the PR or
+  plan evidence.
+- Add fail-closed documentation, source, suite, roadmap, changelog, and plan
+  contracts plus hostile mutations.
+
+## Verification
+
+- focused moderation-guide and filter/fallback contracts
+- repository and external-directory `make check`
+- hostile review-scope, harmful-category, rationale, fallback, fixture,
+  privacy, evidence, roadmap, suite, and plan-status mutations
+- final artifact, credential, exact-diff, and hosted verification audits
+
+## Scope Boundary
+
+This change does not add stereotype content, remove blocked terms, classify
+real users, replace human review with automation, or claim that the current
+filter catches every harmful response.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -70,6 +70,9 @@ MESSENGER_BATCH_PLAN_PATH = (
 MAKE_ROOT_PROTECTION_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-14-make-root-override-protection.md"
 )
+MODERATION_REVIEW_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-14-moderation-review-guide.md"
+)
 
 
 class FakeBottle:
@@ -244,6 +247,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_REPLAY_PLAN_PATH, "Messenger replay guard")
     assert_completed_plan(MESSENGER_BATCH_PLAN_PATH, "Messenger batch processing bound")
     assert_completed_plan(MAKE_ROOT_PROTECTION_PLAN_PATH, "Make root override protection")
+    assert_completed_plan(MODERATION_REVIEW_PLAN_PATH, "moderation review guide")
 
 
 def test_runtime_and_ci_contracts():
@@ -981,6 +985,30 @@ def test_filtered_responses_use_reviewed_fallback():
     assert_true("testAcceptableResponsePassesThroughFilter" in runtime_tests, "runtime tests must cover accepted response passthrough")
 
 
+def test_moderation_review_guide_is_auditable():
+    guide = (ROOT / "MODERATION.md").read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    vision = (ROOT / "VISION.md").read_text(encoding="utf-8")
+    changes = (ROOT / "CHANGES.md").read_text(encoding="utf-8")
+
+    for phrase in (
+            "human content review",
+            "not a complete moderation system",
+            "protected-class stereotypes",
+            "record the rationale",
+            "reviewed value from `config.NONE_RESPONSES`",
+            "accepted-boundary and rejected-boundary regression fixtures",
+            "web, Slack, Messenger, terminal",
+            "Never add real conversation transcripts",
+            "reviewer, review date, changed content scope",
+            "unresolved harmful-content concerns block merge"):
+        assert_true(phrase in guide, "moderation guide must include {0}".format(phrase))
+    assert_true("See `MODERATION.md`" in readme, "README must link the moderation guide")
+    assert_true("docs/plans/2026-06-14-moderation-review-guide.md" in readme, "README must link the moderation plan")
+    assert_true("Require auditable human review" in vision, "VISION must preserve moderation review")
+    assert_true("mandatory human moderation checklist" in changes, "CHANGES must record moderation guide")
+
+
 def test_slack_command_requires_matching_token():
     app, request, response, _requests = load_app()
 
@@ -1121,6 +1149,7 @@ def main():
         test_web_template_escapes_chat_strings,
         test_bot_logging_avoids_private_message_text,
         test_filtered_responses_use_reviewed_fallback,
+        test_moderation_review_guide_is_auditable,
         test_slack_command_requires_matching_token,
         test_slack_command_accepts_matching_token,
         test_slack_command_rejects_blank_text,


### PR DESCRIPTION
## Summary

Valleybot moderation-sensitive changes now have a concrete human review boundary before merge. Reviewers can consistently evaluate response templates, blocked terms, reviewed fallbacks, regression fixtures, channel parity, privacy, and unresolved harmful-content concerns instead of relying on undocumented judgment.

## Baseline

The runtime already rejected known blocked prefixes and returned reviewed fallback text, but the repository did not define the human review evidence required when that content policy changes.

## Improvements

- Establishes an auditable moderation checklist and makes unresolved harmful-content concerns merge-blocking.
- Requires synthetic accepted and rejected boundary fixtures, reviewed fallback verification, and consistent behavior across every delivery channel.
- Adds mutation-sensitive repository contracts so the guide, roadmap priority, changelog record, and completed plan cannot silently regress.

## Validation

- `make check PYTHON=/tmp/valleybot-python314-pip-venv/bin/python`
- `make -C /home/gjones/code/private/worktrees/valleybot-make-root-protection-20260614 check PYTHON=/tmp/valleybot-python314-pip-venv/bin/python` from `/tmp`
- 49 dependency-free contract checks and 27 runtime tests passed in both full gates.
- Ten hostile documentation and contract mutations were rejected.
- Exact diff, generated-artifact, credential-pattern, and whitespace audits passed.

## Risk

Low. This change does not alter response generation or filtering behavior. Its main risk is making the review contract too narrow, mitigated by explicit harm categories, channel coverage, synthetic fixtures, reviewer evidence, and a merge block for unresolved concerns.

## Follow-Ups

Hosted push and pull-request checks are tracked against the exact PR head. This stacked PR must remain based on `lfg/valleybot-make-root-protection-20260614` until its prerequisite PR is merged or rebased with owner authorization.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
