### PR TITLE
ci: add CodeQL and close reflected XSS

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,3 +37,27 @@ jobs:
         run: make check PYTHON=python
       - name: Verify external working directory
         run: cd "$(mktemp -d)" && make -C "$GITHUB_WORKSPACE" check PYTHON=python
+
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - name: Analyze
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-14
 
+- Escaped verified Messenger webhook challenges to close the reflected-XSS
+  finding reported by CodeQL.
 - Added pinned, least-privilege CodeQL analysis for GitHub Actions and Python
   to every hosted push and pull request.
 - Added a mandatory human moderation checklist for response templates, blocked

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-14
 
+- Added pinned, least-privilege CodeQL analysis for GitHub Actions and Python
+  to every hosted push and pull request.
 - Added a mandatory human moderation checklist for response templates, blocked
   terms, reviewed fallbacks, regression boundaries, channel consistency,
   synthetic fixtures, reviewer evidence, and unresolved concerns.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   3.10, 3.12, and 3.14 on Ubuntu 24.04 with read-only permissions, immutable
   action pins, credential-free checkout, cancellation for superseded runs, and
   verification from outside the repository directory.
+- A separate pinned CodeQL job analyzes GitHub Actions and Python. Global
+  permissions remain read-only; only that job receives the
+  `security-events: write` permission needed to upload results.
 - Completed maintenance plans live under `docs/plans` and are checked by
   `make check`.
 - See `docs/plans/2026-06-13-messenger-message-replay-guard.md` for the bounded
@@ -146,6 +149,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   moderation fallback and runtime regression coverage.
 - See `docs/plans/2026-06-14-moderation-review-guide.md` for the human content
   review and evidence contract.
+- See `docs/plans/2026-06-14-codeql-analysis.md` for the pinned,
+  least-privilege code-scanning contract.
 - See `docs/plans/2026-06-12-messenger-json-content-type.md` for the exact JSON
   media-type requirement on signed Messenger webhook requests.
 - See `docs/plans/2026-06-13-messenger-echo-guard.md` for ignoring page echo

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - `REQUEST_TIMEOUT` optionally overrides outbound Messenger request timeout
   seconds; invalid, non-finite, or non-positive values fall back to `5.0`.
 - Messenger webhook request bodies are limited to 1 MiB.
+- Verified Messenger GET challenges are HTML-escaped before response delivery,
+  so hostile markup cannot become reflected page content.
 
 ## Security and Privacy Notes
 
@@ -151,6 +153,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   review and evidence contract.
 - See `docs/plans/2026-06-14-codeql-analysis.md` for the pinned,
   least-privilege code-scanning contract.
+- See `docs/plans/2026-06-14-messenger-challenge-escaping.md` for the reflected
+  challenge boundary found by CodeQL.
 - See `docs/plans/2026-06-12-messenger-json-content-type.md` for the exact JSON
   media-type requirement on signed Messenger webhook requests.
 - See `docs/plans/2026-06-13-messenger-echo-guard.md` for ignoring page echo

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,8 @@ Helpful reports include:
 - Review found infrastructure, deployment, proxy, or cloud configuration; changes in those areas should receive security-focused review before merge.
 - Dependency manifests detected: requirements.txt. Dependency updates should preserve lockfiles when present and avoid introducing packages without a clear maintenance reason.
 - GitHub Actions runs the dependency-free `make check` baseline; review workflow, checker, and deployment-script changes as part of the supply-chain surface.
+- CodeQL analyzes GitHub Actions and Python with immutable action pins and an
+  upload permission scoped to the analysis job.
 
 ## Service and API Notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,8 @@ Helpful reports include:
 Messenger POST webhooks are accepted only when `X-Hub-Signature-256` matches
 the raw request body under `MESSENGER_APP_SECRET`. Keep that secret distinct
 from page and verification tokens and rotate it if webhook logs expose it.
+Verified Messenger GET challenges are escaped before response delivery so a
+valid verification token cannot reflect executable markup into a browser.
 Webhook bodies larger than 1 MiB are rejected with HTTP 413 before signature
 verification, JSON parsing, response generation, or outbound API calls.
 Messenger POST requests must use the `application/json` media type; optional

--- a/VISION.md
+++ b/VISION.md
@@ -35,6 +35,8 @@ Priority:
 - Keep outbound request timeout configuration bounded and non-crashing
 - Maintain the response filter and tests
 - Keep the dependency-free `make check` baseline running in GitHub Actions
+- Keep pinned CodeQL coverage for GitHub Actions and Python with job-scoped
+  upload permission
 - Return reviewed fallback text when a generated response fails moderation
 - Avoid expanding stereotype content without review
 - Require auditable human review of response templates, blocked terms,

--- a/VISION.md
+++ b/VISION.md
@@ -37,6 +37,7 @@ Priority:
 - Keep the dependency-free `make check` baseline running in GitHub Actions
 - Keep pinned CodeQL coverage for GitHub Actions and Python with job-scoped
   upload permission
+- Escape verified Messenger challenge responses before reflecting them
 - Return reviewed fallback text when a generated response fails moderation
 - Avoid expanding stereotype content without review
 - Require auditable human review of response templates, blocked terms,

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from sys import argv
 from collections import OrderedDict
+from html import escape
 import os
 import threading
 from bottle import Bottle, template, request, response, debug
@@ -78,7 +79,7 @@ def messenger_webhook():
     if not challenge:
         response.status = 400
         return "missing challenge"
-    return challenge
+    return escape(challenge, quote=True)
 
 
 @app.post('/messenger/webhook')

--- a/bot_tests.py
+++ b/bot_tests.py
@@ -186,6 +186,19 @@ class TestFacebook(unittest.TestCase):
                          app.settings.messenger_verify_token)
         self.assertEqual(r.text, self.challenge)
 
+    def test_facebook_challenge_escapes_reflected_markup(self):
+        r = test_app.get(
+            '/messenger/webhook',
+            params={
+                'hub.challenge': '<script>alert("xss")</script>',
+                'hub.verify_token': app.settings.messenger_verify_token,
+            },
+        )
+        self.assertEqual(
+            r.text,
+            '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;',
+        )
+
     def test_facebook_challenge_rejects_bad_token(self):
         """
         Test that the webhook rejects invalid verification tokens

--- a/docs/plans/2026-06-14-codeql-analysis.md
+++ b/docs/plans/2026-06-14-codeql-analysis.md
@@ -1,0 +1,43 @@
+# CodeQL Analysis
+
+## Status: Completed
+
+## Context
+
+The hosted Python matrix and local security contracts are green, but GitHub
+reports no code-scanning analysis for the repository. Python source and
+workflow changes therefore lack a first-party static security signal.
+
+## Priority
+
+Add pinned, least-privilege CodeQL analysis to the existing hosted workflow
+without weakening runtime coverage or creating a second workflow surface.
+
+## Requirements
+
+- Analyze GitHub Actions and Python on every push, pull request, and manual
+  workflow dispatch.
+- Keep global workflow permissions read-only and grant
+  `security-events: write` only to the CodeQL job.
+- Pin CodeQL initialization and analysis to an immutable action SHA.
+- Preserve the complete Python matrix, dependency installation,
+  credential-free checkout, and repository plus external-directory checks.
+- Extend the action allowlist and documentation contracts so language,
+  permission, checkout, and analysis drift fails closed.
+- Reject hostile mutations for the language matrix, upload permission,
+  immutable action pin, and analysis step.
+
+## Verification
+
+- Python checker compilation, workflow YAML parsing, and focused runtime/CI
+  contracts passed.
+- The repository and external-directory `make check` passed.
+- Four hostile CodeQL workflow mutations were rejected across the language
+  matrix, upload permission, immutable action pin, and analysis step.
+- Final artifact, corpus-integrity, credential, exact-diff, and hosted checks
+  remain the shipping gate.
+
+## Scope Boundary
+
+This change does not alter bot behavior, content moderation, live Messenger or
+Slack integrations, repository-level secret scanning, or dependency versions.

--- a/docs/plans/2026-06-14-messenger-challenge-escaping.md
+++ b/docs/plans/2026-06-14-messenger-challenge-escaping.md
@@ -1,0 +1,36 @@
+# Messenger Challenge Escaping
+
+## Status: Completed
+
+## Context
+
+The new Python CodeQL analysis identified the verified Messenger webhook
+challenge response as reflected user input. A valid verification token should
+not allow markup in `hub.challenge` to be rendered as HTML.
+
+## Priority
+
+Preserve legitimate verification challenges while neutralizing reflected
+markup before Bottle writes the response.
+
+## Requirements
+
+- Escape the validated challenge with Python's standard HTML escaping helper.
+- Preserve numeric and ordinary text challenges unchanged.
+- Keep token mismatch and missing-challenge responses unchanged.
+- Add dependency-free and Bottle/WebTest regressions for hostile markup.
+- Record the boundary in repository security and maintenance guidance.
+
+## Verification
+
+- Focused dependency-free and Bottle/WebTest challenge regressions passed.
+- The repository and external-directory `make check` passed.
+- A hostile source mutation that restored the raw challenge return was
+  rejected by the contract gate.
+- Final artifact, credential, exact-diff, and exact-head CodeQL closure remain
+  the shipping gate.
+
+## Scope Boundary
+
+This change does not alter verification-token comparison, POST webhook
+handling, message generation, moderation, or live provider credentials.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -73,6 +73,9 @@ MAKE_ROOT_PROTECTION_PLAN_PATH = (
 MODERATION_REVIEW_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-14-moderation-review-guide.md"
 )
+CODEQL_ANALYSIS_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-14-codeql-analysis.md"
+)
 
 
 class FakeBottle:
@@ -248,6 +251,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_BATCH_PLAN_PATH, "Messenger batch processing bound")
     assert_completed_plan(MAKE_ROOT_PROTECTION_PLAN_PATH, "Make root override protection")
     assert_completed_plan(MODERATION_REVIEW_PLAN_PATH, "moderation review guide")
+    assert_completed_plan(CODEQL_ANALYSIS_PLAN_PATH, "CodeQL analysis")
 
 
 def test_runtime_and_ci_contracts():
@@ -275,6 +279,13 @@ def test_runtime_and_ci_contracts():
             'python-version: ["3.10", "3.12", "3.14"]',
             "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
             "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
+            "name: CodeQL (${{ matrix.language }})",
+            "security-events: write",
+            "language: [actions, python]",
+            "github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e",
+            "languages: ${{ matrix.language }}",
+            "build-mode: none",
+            "github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e",
             "persist-credentials: false",
             "python -m pip install -r requirements.txt",
             "make check PYTHON=python",
@@ -286,8 +297,9 @@ def test_runtime_and_ci_contracts():
     assert_true("branches:" not in workflow, "CI push checks must cover every branch")
     assert_true("# v6.0.3" in workflow, "checkout pin annotation must identify the exact release")
     assert_true("# v6.2.0" in workflow, "setup-python pin annotation must identify the exact release")
-    assert_equal(workflow.count("persist-credentials:"), 1, "checkout credential setting count")
+    assert_equal(workflow.count("persist-credentials:"), 2, "checkout credential setting count")
     assert_true("persist-credentials: true" not in workflow, "checkout credentials must not persist")
+    assert_equal(workflow.count("security-events: write"), 1, "CodeQL upload permission count")
 
     action_uses = []
     for line in workflow.splitlines():
@@ -296,25 +308,46 @@ def test_runtime_and_ci_contracts():
             action_line = action_line[2:]
         if action_line.startswith("uses: "):
             action_uses.append(action_line)
-    assert_equal(len(action_uses), 2, "CI action count")
+    assert_equal(len(action_uses), 5, "CI action count")
     assert_equal(
         set(action_uses),
         {
             "uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3",
             "uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0",
+            "uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4",
+            "uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4",
         },
         "CI action allowlist",
+    )
+    assert_equal(
+        action_uses.count(
+            "uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"
+        ),
+        2,
+        "credential-free checkout job count",
     )
     workflow_files = list((ROOT / ".github" / "workflows").glob("*.y*ml"))
     assert_equal(workflow_files, [CI_WORKFLOW_PATH], "CI workflow file set")
 
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     assert_true("GitHub Actions" in readme, "README must document the GitHub Actions check")
+    assert_true("Actions and Python" in readme, "README must document CodeQL languages")
+    assert_true("security-events: write" in readme, "README must document scoped CodeQL upload permission")
     gitignore = (ROOT / ".gitignore").read_text(encoding="utf-8")
     assert_true("!.github/workflows/check.yml" in gitignore, "workflow file must not be hidden by dotfile ignores")
     security = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
     for security_contract in ("X-Hub-Signature-256", "MESSENGER_APP_SECRET", "1 MiB"):
         assert_true(security_contract in security, "SECURITY.md must document {0}".format(security_contract))
+    assert_true("CodeQL analyzes GitHub Actions and Python" in security, "SECURITY.md must document CodeQL coverage")
+    vision = (ROOT / "VISION.md").read_text(encoding="utf-8")
+    assert_true("Keep pinned CodeQL coverage" in vision, "VISION.md must preserve CodeQL coverage")
+    changes = (ROOT / "CHANGES.md").read_text(encoding="utf-8")
+    assert_true("least-privilege CodeQL analysis" in changes, "CHANGES.md must record CodeQL analysis")
+    codeql_plan = CODEQL_ANALYSIS_PLAN_PATH.read_text(encoding="utf-8")
+    for plan_contract in (
+            "The repository and external-directory `make check` passed.",
+            "Four hostile CodeQL workflow mutations were rejected"):
+        assert_true(plan_contract in codeql_plan, "CodeQL plan must record {0}".format(plan_contract))
 
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
     makefile_lines = set(makefile.splitlines())

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -76,6 +76,9 @@ MODERATION_REVIEW_PLAN_PATH = (
 CODEQL_ANALYSIS_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-14-codeql-analysis.md"
 )
+MESSENGER_CHALLENGE_ESCAPE_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-14-messenger-challenge-escaping.md"
+)
 
 
 class FakeBottle:
@@ -252,6 +255,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MAKE_ROOT_PROTECTION_PLAN_PATH, "Make root override protection")
     assert_completed_plan(MODERATION_REVIEW_PLAN_PATH, "moderation review guide")
     assert_completed_plan(CODEQL_ANALYSIS_PLAN_PATH, "CodeQL analysis")
+    assert_completed_plan(MESSENGER_CHALLENGE_ESCAPE_PLAN_PATH, "Messenger challenge escaping")
 
 
 def test_runtime_and_ci_contracts():
@@ -348,6 +352,15 @@ def test_runtime_and_ci_contracts():
             "The repository and external-directory `make check` passed.",
             "Four hostile CodeQL workflow mutations were rejected"):
         assert_true(plan_contract in codeql_plan, "CodeQL plan must record {0}".format(plan_contract))
+    challenge_plan = MESSENGER_CHALLENGE_ESCAPE_PLAN_PATH.read_text(encoding="utf-8")
+    for plan_contract in (
+            "The repository and external-directory `make check` passed.",
+            "hostile source mutation that restored the raw challenge return was"):
+        assert_true(plan_contract in challenge_plan, "challenge plan must record {0}".format(plan_contract))
+    assert_true("HTML-escaped before response delivery" in readme, "README must document challenge escaping")
+    assert_true("valid verification token cannot reflect executable markup" in security, "SECURITY.md must document challenge escaping")
+    assert_true("Escape verified Messenger challenge responses" in vision, "VISION.md must preserve challenge escaping")
+    assert_true("reflected-XSS" in changes, "CHANGES.md must record challenge escaping")
 
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
     makefile_lines = set(makefile.splitlines())
@@ -366,6 +379,10 @@ def test_runtime_and_ci_contracts():
     assert_true("test_facebook_webhook_rejects_oversized_payload" in runtime_tests, "Bottle/WebTest must cover oversized Messenger payloads")
     assert_true("is_json_content_type" in app_source, "Messenger POST requests must require JSON media types")
     assert_true("test_facebook_webhook_rejects_non_json_content_type" in runtime_tests, "Bottle/WebTest must cover non-JSON Messenger payloads")
+    assert_true("from html import escape" in app_source, "Messenger challenge responses must use standard HTML escaping")
+    assert_true("return escape(challenge, quote=True)" in app_source, "verified Messenger challenges must be escaped")
+    assert_true("test_facebook_challenge_escapes_reflected_markup" in runtime_tests, "Bottle/WebTest must cover reflected challenge markup")
+    assert_true("test_messenger_verification_escapes_reflected_markup" in Path(__file__).read_text(encoding="utf-8"), "dependency-free contracts must cover reflected challenge markup")
 
 
 def test_messenger_post_rejects_oversized_declared_body():
@@ -455,6 +472,25 @@ def test_messenger_verification_accepts_matching_token():
 
     assert_equal(body, "challenge-1", "valid verify token challenge")
     assert_equal(response.status, 200, "valid verify token status")
+
+
+def test_messenger_verification_escapes_reflected_markup():
+    app, request, response, _requests = load_app()
+
+    request.query = {
+        "hub.challenge": '<script>alert("xss")</script>',
+        "hub.verify_token": "verify-secret",
+    }
+    response.status = 200
+
+    body = app.messenger_webhook()
+
+    assert_equal(
+        body,
+        "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;",
+        "verified challenge markup must be escaped",
+    )
+    assert_equal(response.status, 200, "escaped challenge status")
 
 
 def test_messenger_post_ignores_non_message_events():
@@ -1152,6 +1188,7 @@ def main():
         test_messenger_post_rejects_non_json_content_types_before_authentication,
         test_messenger_verification_requires_matching_token,
         test_messenger_verification_accepts_matching_token,
+        test_messenger_verification_escapes_reflected_markup,
         test_messenger_post_ignores_non_message_events,
         test_messenger_post_ignores_echoes_and_continues_scanning,
         test_messenger_post_requires_boolean_true_echo_flag,


### PR DESCRIPTION
## Summary

Valleybot now produces first-party code-scanning results instead of reporting that no analysis exists. The first analysis exposed a high-severity reflected-XSS path in Messenger verification; the same PR now escapes verified challenge markup while preserving legitimate challenges.

## Baseline

The stacked base at `5e04a52f9d4a797d24694726fc7ac85009770b31` had six successful Python matrix checks but no code-scanning analysis. Initial CodeQL head `d91b8abe13bb6c712d27a7cc326fa3951438dfac` reported `py/reflective-xss` at `app.py:81`.

## Improvements

- Pin CodeQL initialization and analysis to immutable action SHA `8aad20d150bbac5944a9f9d289da16a4b0d87c1e` for GitHub Actions and Python.
- Preserve the existing Python matrix and grant `security-events: write` only inside the CodeQL job.
- Escape the token-validated Messenger `hub.challenge` with Python's standard HTML helper before returning it.
- Add dependency-free and Bottle/WebTest regressions plus fail-closed source, documentation, and plan contracts.

## Validation

- Repository and external-directory `make check`: 50 contracts and 28 Bottle/WebTest runtime tests passed
- Four hostile workflow mutations rejected
- Raw challenge-return mutation rejected by the escaping contract
- Tracked NLTK corpus identity preserved; four explicit downloader outputs removed
- Artifact, exact-diff, whitespace, and credential audits passed

## Risk

Legitimate numeric and ordinary-text verification challenges are unchanged; only HTML-significant characters are encoded after successful token validation. The exact new head must prove both canonical events green and close the CodeQL alert before completion.

## Follow-Ups

Repository-level secret scanning and Dependabot alerts remain disabled or inaccessible. PR #17 remains stacked on PR #16 and must not be merged or closed without explicit authorization.

## Post-Deploy Monitoring & Validation

- **Owner:** repository maintainers
- **Window:** the first push and pull-request runs for exact head `ca07cc1`
- **Healthy:** all Python and CodeQL jobs succeed, the branch has Actions and Python analyses, and alert #1 is fixed or absent on the exact head
- **Failure:** any workflow regression, a remaining `py/reflective-xss` alert, or changed legitimate challenge behavior
- **Mitigation:** inspect bounded logs and alert instances; revert the two XSS follow-up commits if the challenge contract cannot be corrected without breaking verification

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
