### PR TITLE
Fix external Makefile root resolution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-15
+
+- Anchored Make cleanup and verification to the loaded Makefile directory so
+  external `make -f` invocations cannot target the caller's filesystem tree.
+
 ## 2026-06-14
 
 - Escaped verified Messenger webhook challenges to close the reflected-XSS

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON ?= python3
-override ROOT := $(CURDIR)
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 PYTHON_FILES := \
 	app.py \

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   413 before signature verification or JSON parsing. Generated responses that
   fail moderation use a reviewed generic fallback instead of failing a request.
 - `make check` runs `make verify` with bytecode cleanup before and after.
-  The Makefile uses make's selected directory as the repository root, so the
-  same gate can run from an external working directory with `make -C`.
+  The Makefile derives the repository root from its own location, so the same
+  gate can run from an external working directory with
+  `make -f /path/to/valleybot/Makefile check`.
 - `make prepare-corpora` installs the current TextBlob tokenizer and tagger
   data into the existing project-local `nltk_data` directory. Heroku runs the
   same step through `bin/post_compile`.

--- a/docs/plans/2026-06-15-makefile-location-root.md
+++ b/docs/plans/2026-06-15-makefile-location-root.md
@@ -1,6 +1,6 @@
 # Anchor Make Cleanup to the Makefile Location
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -27,3 +27,23 @@ outside the checkout therefore sends recursive cleanup into the caller's tree.
 
 - Do not change bot behavior, dependencies, workflows, or tracked NLTK data.
 - Do not merge or close stacked pull requests without owner authorization.
+
+## Work Completed
+
+- Replaced the protected caller-directory root with the absolute directory of
+  the last loaded Makefile.
+- Added fail-closed contracts for the exact rooted declaration and rejection
+  of `CURDIR`.
+- Updated local verification documentation without changing runtime behavior.
+
+## Verification
+
+- The focused checker passed 50 dependency-free contracts.
+- Caller-directory and missing-`override` mutations were rejected, and a
+  hostile command-line `ROOT` assignment could not redirect any dry-run path.
+- Repository and external-directory `make check` passed with a pinned Python
+  environment: 50 contracts and 28 runtime tests in each run.
+- `pip check` passed and `pip-audit` found no known vulnerabilities in auditable
+  dependencies; the pinned private WebOb build was explicitly unauditable.
+- Tracked NLTK corpus hashes remained unchanged. Four downloader outputs were
+  removed by exact path after validation.

--- a/docs/plans/2026-06-15-makefile-location-root.md
+++ b/docs/plans/2026-06-15-makefile-location-root.md
@@ -1,0 +1,29 @@
+# Anchor Make Cleanup to the Makefile Location
+
+## Status: In Progress
+
+## Context
+
+The current protected `ROOT := $(CURDIR)` cannot be overridden, but it still
+trusts the caller's working directory. Running `make -f /path/to/Makefile check`
+outside the checkout therefore sends recursive cleanup into the caller's tree.
+
+## Requirements
+
+- Derive the protected repository root from the loaded Makefile location.
+- Keep cleanup, source checks, corpora preparation, tests, and recursion inside
+  the checkout for repository and external-directory invocations.
+- Preserve explicit `PYTHON` overrides and existing runtime behavior.
+- Add fail-closed static contracts for the exact rooted declaration and reject
+  the caller-directory form.
+
+## Verification Plan
+
+- focused contract checker and hostile root-declaration mutations
+- repository and external-directory `make check` with bounded execution
+- diff, generated-artifact, tracked-corpus, and credential-pattern audits
+
+## Scope Boundaries
+
+- Do not change bot behavior, dependencies, workflows, or tracked NLTK data.
+- Do not merge or close stacked pull requests without owner authorization.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -79,6 +79,9 @@ CODEQL_ANALYSIS_PLAN_PATH = (
 MESSENGER_CHALLENGE_ESCAPE_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-14-messenger-challenge-escaping.md"
 )
+MAKEFILE_LOCATION_ROOT_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-15-makefile-location-root.md"
+)
 
 
 class FakeBottle:
@@ -256,6 +259,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MODERATION_REVIEW_PLAN_PATH, "moderation review guide")
     assert_completed_plan(CODEQL_ANALYSIS_PLAN_PATH, "CodeQL analysis")
     assert_completed_plan(MESSENGER_CHALLENGE_ESCAPE_PLAN_PATH, "Messenger challenge escaping")
+    assert_completed_plan(MAKEFILE_LOCATION_ROOT_PLAN_PATH, "Makefile location root")
 
 
 def test_runtime_and_ci_contracts():
@@ -364,7 +368,12 @@ def test_runtime_and_ci_contracts():
 
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
     makefile_lines = set(makefile.splitlines())
-    assert_true("override ROOT := $(CURDIR)" in makefile_lines, "Makefile must protect make's selected working directory as the repository root")
+    assert_true(
+        "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))"
+        in makefile_lines,
+        "Makefile must protect the loaded Makefile directory as the repository root",
+    )
+    assert_true("$(CURDIR)" not in makefile, "Makefile root must not trust the caller directory")
     assert_true("PYTHON ?= python3" in makefile_lines, "Makefile must preserve the Python command override")
     assert_true('find "$(ROOT)"' in makefile, "Makefile cleanup must stay inside the repository")
     assert_true('"$(ROOT)/scripts/check_valleybot_contracts.py"' in makefile, "Makefile must use the rooted contract path")


### PR DESCRIPTION
## Summary

Anchor Valleybot's protected Make root to the loaded Makefile directory so external `make -f` invocations cannot clean or validate the caller's filesystem tree.

## Baseline

The stacked base protected `ROOT` from command-line overrides but derived it from `CURDIR`; invoking the Makefile from `/tmp` attempted recursive bytecode cleanup under `/tmp` and failed on unrelated protected files.

## Improvements

Use `MAKEFILE_LIST` to derive the absolute checkout root, reject `CURDIR` in the fail-closed checker, register a completed plan, and update verification documentation.

## Validation

Repository and external-directory pinned `make check` each passed 50 dependency-free contracts and 28 runtime tests. Caller-directory, missing-override, and hostile command-line root mutations were rejected. `pip check` passed; `pip-audit` found no known vulnerabilities in auditable dependencies and explicitly skipped the private WebOb build.

## Risk

Runtime behavior, dependencies, workflows, and tracked NLTK corpora are unchanged. Validation downloads were removed by exact path, and tracked corpus hashes remained identical.

## Follow-Ups

PR #18 is stacked on PR #17 and should remain open until the earlier stack is reviewed. No existing pull request should be merged or closed without owner authorization.
