### PR TITLE
Reject failed Messenger provider replies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Anchored Make cleanup and verification to the loaded Makefile directory so
   external `make -f` invocations cannot target the caller's filesystem tree.
+- Rejected unsuccessful Messenger provider responses before accepting reply
+  content, allowing failed message-ID claims to be retried.
 
 ## 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   webhook text, and Messenger sender IDs must be valid before response
   generation. Recent Messenger message IDs are claimed in a bounded in-memory
   cache so provider retries do not send duplicate replies; outbound exceptions
-  release their claim for recovery. Signed webhook batches process up to 20
-  valid user messages in payload order. Messenger POST bodies larger than 1 MiB are rejected with HTTP
+  release their claim for recovery. Unsuccessful provider HTTP responses raise
+  before reply content is accepted, allowing the webhook delivery to be
+  retried. Signed webhook batches process up to 20 valid user messages in
+  payload order. Messenger POST bodies larger than 1 MiB are rejected with HTTP
   413 before signature verification or JSON parsing. Generated responses that
   fail moderation use a reviewed generic fallback instead of failing a request.
 - `make check` runs `make verify` with bytecode cleanup before and after.
@@ -160,6 +162,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   media-type requirement on signed Messenger webhook requests.
 - See `docs/plans/2026-06-13-messenger-echo-guard.md` for ignoring page echo
   messages without hiding later user messages in the same webhook payload.
+- See `docs/plans/2026-06-15-messenger-reply-http-status.md` for provider HTTP
+  failure handling and replay-claim recovery.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,6 +52,8 @@ Recent non-empty Messenger message IDs are claimed before outbound replies in a
 bounded process-local cache. Duplicate deliveries are acknowledged without a
 second reply, and outbound exceptions release their claim. This protection
 does not span multiple workers or process restarts.
+Provider HTTP errors propagate through the webhook handler and release any
+message-ID claim so a later provider delivery can retry the outbound reply.
 Each signed webhook processes at most 20 valid user messages in payload order,
 limiting outbound reply amplification while preserving per-message replay
 claims and failure release.

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,8 @@ Priority:
 - Suppress duplicate Messenger replies from retried message IDs with bounded
   process-local state
 - Process Messenger message batches in order with a fixed per-webhook cap
+- Fail Messenger replies on provider HTTP errors so webhook retries remain
+  recoverable
 - Reject empty web chat queries before response generation
 - Render web chat replies as text instead of concatenated HTML
 - Reject malformed low-level bot JSON requests before response generation

--- a/app.py
+++ b/app.py
@@ -255,6 +255,7 @@ def messenger_reply(user_id, msg):
         json=data,
         headers=headers,
         timeout=settings.request_timeout)
+    resp.raise_for_status()
     return resp.content
 
 

--- a/bot_tests.py
+++ b/bot_tests.py
@@ -159,6 +159,9 @@ class TestFacebook(unittest.TestCase):
             def __init__(self, user_id):
                 self.content = json.dumps({'recipient_id': user_id})
 
+            def raise_for_status(self):
+                return None
+
         def fake_post(url, **kwargs):
             calls.append((url, kwargs))
             return FakeResponse(self.user_id)
@@ -175,6 +178,22 @@ class TestFacebook(unittest.TestCase):
         self.assertEqual(calls[0][1]['headers']['Authorization'],
                          'Bearer ' + app.settings.messenger_token)
         self.assertEqual(calls[0][1]['timeout'], app.settings.request_timeout)
+
+    def test_facebook_response_raises_for_http_error(self):
+        original_post = app.requests.post
+
+        class FailedResponse(object):
+            content = b'provider error'
+
+            def raise_for_status(self):
+                raise RuntimeError('provider rejected reply')
+
+        app.requests.post = lambda _url, **_kwargs: FailedResponse()
+        try:
+            with self.assertRaisesRegex(RuntimeError, 'provider rejected reply'):
+                app.messenger_reply(self.user_id, 'hello this is a test')
+        finally:
+            app.requests.post = original_post
 
     def test_facebook_challenge(self):
         """

--- a/docs/plans/2026-06-15-messenger-reply-http-status.md
+++ b/docs/plans/2026-06-15-messenger-reply-http-status.md
@@ -1,6 +1,6 @@
 # Fail Messenger Replies on Provider HTTP Errors
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -31,8 +31,25 @@ message ID claimed and suppressing a legitimate webhook retry.
 - Do not add retries, change provider endpoints, or change token handling.
 - Do not merge or close stacked pull requests without owner authorization.
 
-## Work Pending
+## Work Completed
 
-- Add the provider HTTP status boundary and mutation-sensitive regression.
-- Update operator and security documentation.
-- Run the planned bounded validation and record the actual evidence.
+- Added an explicit provider HTTP status check before reply content is accepted.
+- Added dependency-free and Bottle/WebTest regressions that prove provider HTTP
+  errors propagate and release replay claims for a later webhook delivery.
+- Added fail-closed source-order, runtime-test, documentation, and completed-plan
+  contracts, plus operator and security documentation.
+
+## Verification
+
+- The focused HTTP-status contracts passed, and the full dependency-free suite
+  passed 52 tests.
+- Repository and external-directory `make check` passed under a clean pinned
+  Python 3.12 environment, with 52 contracts and 29 runtime tests in each run.
+- Five targeted mutations were rejected: removed and unreachable status checks,
+  a non-raising fake response, missing runtime coverage, and missing docs.
+- `uv pip check` passed for all 18 installed packages. `pip-audit` reported no
+  known vulnerabilities in auditable packages; the private WebOb build was
+  explicitly reported as unavailable on PyPI and unauditable.
+- The first ambient `make check` attempt stopped before tests because its active
+  interpreter lacked TextBlob; validation was rerun with the clean pinned
+  environment rather than weakening the gate.

--- a/docs/plans/2026-06-15-messenger-reply-http-status.md
+++ b/docs/plans/2026-06-15-messenger-reply-http-status.md
@@ -1,0 +1,38 @@
+# Fail Messenger Replies on Provider HTTP Errors
+
+## Status: In Progress
+
+## Context
+
+The Messenger reply path applies a timeout and bearer authentication, but it
+returns the response body without checking the provider's HTTP status. A 4xx
+or 5xx response is therefore treated as a successful delivery, leaving the
+message ID claimed and suppressing a legitimate webhook retry.
+
+## Requirements
+
+- Raise on unsuccessful Messenger provider HTTP responses before returning the
+  response body.
+- Preserve timeout, header authentication, successful response behavior, and
+  replay handling for messages without usable IDs.
+- Prove that an HTTP failure propagates through the webhook path and releases
+  the replay claim so the same message can be retried.
+- Add fail-closed source and documentation contracts for the new boundary.
+
+## Verification Plan
+
+- focused dependency-free Messenger reply and replay contracts
+- mutation checks that remove or reorder the HTTP status check
+- repository and external-directory `make check` with bounded execution
+- exact diff, generated-artifact, and credential-pattern audits
+
+## Scope Boundaries
+
+- Do not add retries, change provider endpoints, or change token handling.
+- Do not merge or close stacked pull requests without owner authorization.
+
+## Work Pending
+
+- Add the provider HTTP status boundary and mutation-sensitive regression.
+- Update operator and security documentation.
+- Run the planned bounded validation and record the actual evidence.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -82,6 +82,9 @@ MESSENGER_CHALLENGE_ESCAPE_PLAN_PATH = (
 MAKEFILE_LOCATION_ROOT_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-15-makefile-location-root.md"
 )
+MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-15-messenger-reply-http-status.md"
+)
 
 
 class FakeBottle:
@@ -112,14 +115,25 @@ class MutableResponse:
         self.content_type = None
 
 
+class FakeHttpResponse:
+    def __init__(self, error=None):
+        self.content = b'{"recipient_id": "user-1"}'
+        self.error = error
+
+    def raise_for_status(self):
+        if self.error is not None:
+            raise self.error
+
+
 class FakeRequests(types.SimpleNamespace):
     def __init__(self):
         super(FakeRequests, self).__init__()
         self.calls = []
+        self.response_error = None
 
     def post(self, url, **kwargs):
         self.calls.append((url, kwargs))
-        return types.SimpleNamespace(content=b'{"recipient_id": "user-1"}')
+        return FakeHttpResponse(self.response_error)
 
 
 def install_stubs():
@@ -260,6 +274,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(CODEQL_ANALYSIS_PLAN_PATH, "CodeQL analysis")
     assert_completed_plan(MESSENGER_CHALLENGE_ESCAPE_PLAN_PATH, "Messenger challenge escaping")
     assert_completed_plan(MAKEFILE_LOCATION_ROOT_PLAN_PATH, "Makefile location root")
+    assert_completed_plan(MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH, "Messenger reply HTTP status")
 
 
 def test_runtime_and_ci_contracts():
@@ -925,6 +940,53 @@ def test_messenger_reply_uses_header_auth_and_timeout():
     )
 
 
+def test_messenger_post_releases_claim_after_provider_http_error():
+    app, request, _response, requests = load_app()
+    request.json = messenger_payload("mid-provider-http-error")
+    requests.response_error = RuntimeError("provider rejected reply")
+
+    try:
+        app.messenger_post()
+        raise AssertionError("Messenger provider HTTP errors must propagate")
+    except RuntimeError as exc:
+        assert_equal(str(exc), "provider rejected reply", "provider HTTP error")
+
+    requests.response_error = None
+    assert_equal(app.messenger_post(), "ok", "retry after provider HTTP error")
+    assert_equal(len(requests.calls), 2, "provider HTTP error must release replay claim")
+
+
+def test_messenger_reply_http_status_source_contracts():
+    source = (ROOT / "app.py").read_text(encoding="utf-8")
+    runtime_tests = (ROOT / "bot_tests.py").read_text(encoding="utf-8")
+    reply_start = source.index("def messenger_reply")
+    reply_end = source.index("# WEB BOT INTEGRATION", reply_start)
+    reply_source = source[reply_start:reply_end]
+    post_position = reply_source.index("requests.post(")
+    status_position = reply_source.index("resp.raise_for_status()")
+    return_position = reply_source.index("return resp.content")
+    assert_true(
+        post_position < status_position < return_position,
+        "Messenger reply must reject provider HTTP errors before returning content",
+    )
+    assert_true(
+        "test_facebook_response_raises_for_http_error" in runtime_tests,
+        "Bottle/WebTest suite must cover Messenger provider HTTP errors",
+    )
+
+    docs = {
+        "README.md": "Unsuccessful provider HTTP responses raise",
+        "SECURITY.md": "Provider HTTP errors propagate",
+        "VISION.md": "Fail Messenger replies on provider HTTP errors",
+        "CHANGES.md": "Rejected unsuccessful Messenger provider responses",
+    }
+    for relative_path, phrase in docs.items():
+        assert_true(
+            phrase in (ROOT / relative_path).read_text(encoding="utf-8"),
+            "{0} must document Messenger provider HTTP failures".format(relative_path),
+        )
+
+
 def test_request_timeout_accepts_positive_float_env():
     assert_equal(
         load_settings_with_request_timeout("2.5"),
@@ -1218,6 +1280,8 @@ def main():
         test_messenger_replay_source_contracts,
         test_messenger_batch_source_contracts,
         test_messenger_reply_uses_header_auth_and_timeout,
+        test_messenger_post_releases_claim_after_provider_http_error,
+        test_messenger_reply_http_status_source_contracts,
         test_request_timeout_accepts_positive_float_env,
         test_request_timeout_defaults_for_invalid_env,
         test_bot_json_request_rejects_invalid_or_blank_payloads,


### PR DESCRIPTION
## Summary

- reject Messenger provider 4xx/5xx responses before accepting reply content
- release the claimed message ID through the existing exception path so webhook retries remain recoverable
- add dependency-free, Bottle/WebTest, source-order, documentation, and completed-plan contracts

## Baseline

- Messenger provider error responses could reach reply-content handling without an explicit 4xx/5xx rejection boundary.
- Recovery depends on the existing exception path releasing the claimed message ID so webhook retries remain possible.

## Improvements

- Validate Messenger provider HTTP status before accepting reply content.
- Preserve the established exception and message-release behavior for failed provider replies.
- Cover the boundary with dependency-free, integration, source-order, documentation, and completed-plan contracts.

## Validation

- focused Messenger HTTP-status contracts: 3 passed
- dependency-free contracts: 52 passed
- repository and external-directory `make check`: 52 contracts and 29 runtime tests each under pinned Python 3.12
- six targeted mutations rejected, including removed/unreachable status checks and incomplete plan evidence
- `uv pip check`: 18 packages compatible
- `pip-audit`: no known vulnerabilities in auditable packages; private WebOb build explicitly unauditable
- exact diff, generated-artifact, conflict-marker, and high-confidence credential audits passed

## Risk

- Validation is contract-focused and does not exercise a live Messenger provider or production webhook retry flow.
- The private WebOb build cannot be evaluated by `pip-audit`, so its vulnerability state remains outside that audit result.

## Follow-Ups

- Review and merge the stacked base PR before this change to preserve branch ordering.
- Keep live-provider and webhook-retry behavior under operational observation after deployment.

## Stack

Base: #18 (`lfg/valleybot-makefile-location-root-20260615`)
