### PR TITLE
fix: require Messenger subscribe verification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   external `make -f` invocations cannot target the caller's filesystem tree.
 - Rejected unsuccessful Messenger provider responses before accepting reply
   content, allowing failed message-ID claims to be retried.
+- Messenger GET verification requires the exact `subscribe` mode before an
+  authenticated challenge is returned.
 
 ## 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   payload order. Messenger POST bodies larger than 1 MiB are rejected with HTTP
   413 before signature verification or JSON parsing. Generated responses that
   fail moderation use a reviewed generic fallback instead of failing a request.
+  Messenger GET verification requires the exact `subscribe` mode after token
+  authentication and before an escaped challenge is returned.
 - `make check` runs `make verify` with bytecode cleanup before and after.
   The Makefile derives the repository root from its own location, so the same
   gate can run from an external working directory with

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,8 @@ the raw request body under `MESSENGER_APP_SECRET`. Keep that secret distinct
 from page and verification tokens and rotate it if webhook logs expose it.
 Verified Messenger GET challenges are escaped before response delivery so a
 valid verification token cannot reflect executable markup into a browser.
+Messenger GET verification requires the exact `subscribe` mode after token
+authentication and before any challenge is reflected.
 Webhook bodies larger than 1 MiB are rejected with HTTP 413 before signature
 verification, JSON parsing, response generation, or outbound API calls.
 Messenger POST requests must use the `application/json` media type; optional

--- a/VISION.md
+++ b/VISION.md
@@ -40,6 +40,8 @@ Priority:
 - Keep pinned CodeQL coverage for GitHub Actions and Python with job-scoped
   upload permission
 - Escape verified Messenger challenge responses before reflecting them
+- Messenger GET verification requires the exact `subscribe` mode after token
+  authentication
 - Return reviewed fallback text when a generated response fails moderation
 - Avoid expanding stereotype content without review
 - Require auditable human review of response templates, blocked terms,

--- a/app.py
+++ b/app.py
@@ -76,6 +76,10 @@ def messenger_webhook():
     if not secure_compare(verify_token, expected_token):
         response.status = 403
         return "forbidden"
+    verification_mode = request.query.get("hub.mode")
+    if verification_mode != "subscribe":
+        response.status = 400
+        return "invalid mode"
     if not challenge:
         response.status = 400
         return "missing challenge"

--- a/bot_tests.py
+++ b/bot_tests.py
@@ -201,6 +201,7 @@ class TestFacebook(unittest.TestCase):
         """
         r = test_app.get('/messenger/webhook?hub.challenge=' +
                          self.challenge +
+                         '&hub.mode=subscribe' +
                          '&hub.verify_token=' +
                          app.settings.messenger_verify_token)
         self.assertEqual(r.text, self.challenge)
@@ -210,6 +211,7 @@ class TestFacebook(unittest.TestCase):
             '/messenger/webhook',
             params={
                 'hub.challenge': '<script>alert("xss")</script>',
+                'hub.mode': 'subscribe',
                 'hub.verify_token': app.settings.messenger_verify_token,
             },
         )
@@ -224,9 +226,28 @@ class TestFacebook(unittest.TestCase):
         """
         r = test_app.get('/messenger/webhook?hub.challenge=' +
                          self.challenge +
+                         '&hub.mode=subscribe' +
                          '&hub.verify_token=bad-token',
                          expect_errors=True)
         self.assertEqual(r.status_int, 403)
+
+    def test_facebook_challenge_requires_subscribe_mode(self):
+        for mode in (None, '', 'Subscribe', 'unsubscribe'):
+            params = {
+                'hub.challenge': self.challenge,
+                'hub.verify_token': app.settings.messenger_verify_token,
+            }
+            if mode is not None:
+                params['hub.mode'] = mode
+
+            r = test_app.get(
+                '/messenger/webhook',
+                params=params,
+                expect_errors=True,
+            )
+
+            self.assertEqual(r.status_int, 400)
+            self.assertNotEqual(r.text, self.challenge)
 
     def test_facebook_delivery_event_is_ignored(self):
         """

--- a/docs/plans/2026-06-16-messenger-verification-mode.md
+++ b/docs/plans/2026-06-16-messenger-verification-mode.md
@@ -1,0 +1,37 @@
+# Require Messenger Subscription Verification Mode
+
+## Status: Planned
+
+## Context
+
+The Messenger verification endpoint authenticates the verification token and
+escapes the returned challenge, but it does not validate `hub.mode`. A request
+with a matching token can therefore receive the challenge even when it is not
+the platform's `subscribe` verification operation.
+
+## Requirements
+
+- Require the exact `subscribe` verification mode before returning a Messenger
+  challenge.
+- Reject missing, blank, differently cased, and unrelated mode values without
+  reflecting the challenge.
+- Preserve constant-time token comparison, escaped challenge output, and the
+  existing missing-challenge behavior for valid subscription requests.
+- Add dependency-free and Bottle/WebTest regressions plus fail-closed source,
+  documentation, changelog, and completed-plan contracts.
+
+## Verification Plan
+
+- focused Messenger verification-mode contracts before and after implementation
+- Bottle/WebTest coverage for valid, missing, and invalid mode values
+- mutation checks for missing or weakened mode validation and removed evidence
+- repository and external-directory `make check` with bounded execution
+- exact diff, generated-artifact, conflict-marker, and credential-pattern audits
+
+## Scope Boundaries
+
+- Do not change POST signature verification, reply delivery, replay handling,
+  provider endpoints, tokens, or timeout behavior.
+- Do not accept case-folded or whitespace-normalized alternatives to the
+  platform's exact `subscribe` mode.
+- Do not merge or close stacked pull requests without owner authorization.

--- a/docs/plans/2026-06-16-messenger-verification-mode.md
+++ b/docs/plans/2026-06-16-messenger-verification-mode.md
@@ -1,6 +1,6 @@
 # Require Messenger Subscription Verification Mode
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -35,3 +35,24 @@ the platform's `subscribe` verification operation.
 - Do not accept case-folded or whitespace-normalized alternatives to the
   platform's exact `subscribe` mode.
 - Do not merge or close stacked pull requests without owner authorization.
+
+## Work Completed
+
+- Required the exact `subscribe` mode after token authentication and before
+  challenge validation or reflection.
+- Added dependency-free and Bottle/WebTest regressions for valid, missing,
+  blank, differently cased, unrelated, and whitespace-wrapped mode values.
+- Added fail-closed source, test-registration, documentation, changelog, and
+  completed-plan contracts.
+
+## Verification
+
+- `test_messenger_verification_requires_exact_subscribe_mode` passed as part
+  of the 54-test dependency-free contract gate.
+- All 30 Bottle/WebTest tests passed under Python 3.12, the supported runtime
+  for the repository's pinned legacy WebOb dependency.
+- repository and external-directory `make check` passed with bounded
+  execution.
+- Six hostile mutations were rejected, covering inverted and normalized mode
+  checks plus removed dependency-free, Bottle/WebTest, documentation, and plan
+  evidence.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -406,6 +406,10 @@ def test_runtime_and_ci_contracts():
     assert_true("from html import escape" in app_source, "Messenger challenge responses must use standard HTML escaping")
     assert_true("return escape(challenge, quote=True)" in app_source, "verified Messenger challenges must be escaped")
     assert_true("test_facebook_challenge_escapes_reflected_markup" in runtime_tests, "Bottle/WebTest must cover reflected challenge markup")
+    assert_true(
+        "test_facebook_challenge_requires_subscribe_mode" in runtime_tests,
+        "Bottle/WebTest must cover Messenger verification mode",
+    )
     assert_true("test_messenger_verification_escapes_reflected_markup" in Path(__file__).read_text(encoding="utf-8"), "dependency-free contracts must cover reflected challenge markup")
 
 
@@ -477,7 +481,11 @@ def test_messenger_post_rejects_non_json_content_types_before_authentication():
 def test_messenger_verification_requires_matching_token():
     app, request, response, _requests = load_app()
 
-    request.query = {"hub.challenge": "challenge-1", "hub.verify_token": "wrong"}
+    request.query = {
+        "hub.challenge": "challenge-1",
+        "hub.mode": "subscribe",
+        "hub.verify_token": "wrong",
+    }
     response.status = 200
 
     body = app.messenger_webhook()
@@ -489,7 +497,11 @@ def test_messenger_verification_requires_matching_token():
 def test_messenger_verification_accepts_matching_token():
     app, request, response, _requests = load_app()
 
-    request.query = {"hub.challenge": "challenge-1", "hub.verify_token": "verify-secret"}
+    request.query = {
+        "hub.challenge": "challenge-1",
+        "hub.mode": "subscribe",
+        "hub.verify_token": "verify-secret",
+    }
     response.status = 200
 
     body = app.messenger_webhook()
@@ -503,6 +515,7 @@ def test_messenger_verification_escapes_reflected_markup():
 
     request.query = {
         "hub.challenge": '<script>alert("xss")</script>',
+        "hub.mode": "subscribe",
         "hub.verify_token": "verify-secret",
     }
     response.status = 200
@@ -515,6 +528,69 @@ def test_messenger_verification_escapes_reflected_markup():
         "verified challenge markup must be escaped",
     )
     assert_equal(response.status, 200, "escaped challenge status")
+
+
+def test_messenger_verification_requires_exact_subscribe_mode():
+    for mode in (None, "", "Subscribe", "unsubscribe", " subscribe "):
+        app, request, response, _requests = load_app()
+        request.query = {
+            "hub.challenge": "challenge-1",
+            "hub.verify_token": "verify-secret",
+        }
+        if mode is not None:
+            request.query["hub.mode"] = mode
+        response.status = 200
+
+        body = app.messenger_webhook()
+
+        assert_equal(response.status, 400, "invalid verification mode status {0!r}".format(mode))
+        assert_true(body != "challenge-1", "invalid verification mode must not reflect challenge")
+
+
+def test_messenger_verification_mode_source_contracts():
+    source = (ROOT / "app.py").read_text(encoding="utf-8")
+    runtime_tests = (ROOT / "bot_tests.py").read_text(encoding="utf-8")
+    checker_source = Path(__file__).read_text(encoding="utf-8")
+    plan = (ROOT / "docs" / "plans" / "2026-06-16-messenger-verification-mode.md").read_text(
+        encoding="utf-8"
+    )
+
+    for contract in (
+        'verification_mode = request.query.get("hub.mode")',
+        'if verification_mode != "subscribe":',
+        'return "invalid mode"',
+    ):
+        assert_true(contract in source, "missing Messenger verification mode contract {0}".format(contract))
+
+    token_check = source.index("if not secure_compare(verify_token, expected_token):")
+    mode_check = source.index('if verification_mode != "subscribe":')
+    challenge_check = source.index("if not challenge:")
+    challenge_return = source.index("return escape(challenge, quote=True)")
+    assert_true(
+        token_check < mode_check < challenge_check < challenge_return,
+        "Messenger verification must authenticate, validate mode, validate challenge, then escape",
+    )
+
+    assert_true(
+        "test_facebook_challenge_requires_subscribe_mode" in runtime_tests,
+        "Bottle/WebTest must retain invalid Messenger mode coverage",
+    )
+    main_source = checker_source.split("def main():", 1)[1]
+    assert_true(
+        "\n        test_messenger_verification_requires_exact_subscribe_mode,\n" in main_source,
+        "dependency-free Messenger mode coverage must remain registered",
+    )
+    guidance = "Messenger GET verification requires the exact `subscribe` mode"
+    for relative_path in ("README.md", "SECURITY.md", "VISION.md", "CHANGES.md"):
+        document = (ROOT / relative_path).read_text(encoding="utf-8")
+        assert_true(guidance in document, "{0} must document exact Messenger mode".format(relative_path))
+    for contract in (
+        "Status: Completed",
+        "test_messenger_verification_requires_exact_subscribe_mode",
+        "repository and external-directory `make check` passed",
+        "hostile mutations were rejected",
+    ):
+        assert_true(contract in plan, "verification-mode plan must keep {0}".format(contract))
 
 
 def test_messenger_post_ignores_non_message_events():
@@ -1260,6 +1336,8 @@ def main():
         test_messenger_verification_requires_matching_token,
         test_messenger_verification_accepts_matching_token,
         test_messenger_verification_escapes_reflected_markup,
+        test_messenger_verification_requires_exact_subscribe_mode,
+        test_messenger_verification_mode_source_contracts,
         test_messenger_post_ignores_non_message_events,
         test_messenger_post_ignores_echoes_and_continues_scanning,
         test_messenger_post_requires_boolean_true_echo_flag,


### PR DESCRIPTION
## Summary

Messenger verification no longer returns an authenticated challenge for a
missing or non-subscription operation.

## Baseline

The GET webhook could validate and return a Messenger challenge without first
requiring the exact `hub.mode=subscribe` operation.

## Improvements

The GET webhook now requires the exact `hub.mode=subscribe` value, without case
folding or whitespace normalization, before validating and escaping the
challenge.

The regression coverage is fail-closed across the dependency-free contract
gate, Bottle/WebTest, source ordering, documentation, and completed-plan
evidence.

## Validation

- `make check PYTHON=/tmp/valleybot-mode-venv/bin/python`
- `make -f /home/gjones/code/private/worktrees/valleybot-messenger-reply-http-status-20260615/Makefile check PYTHON=/tmp/valleybot-mode-venv/bin/python` from `/tmp`
- 54 dependency-free contract tests and 30 Bottle/WebTest tests passed in each full gate
- Six hostile mutations were rejected

## Risk

No migration or configuration change is required. After deployment, monitor
Messenger GET verification 400 responses for unexpected platform mode values;
valid `subscribe` challenges should continue returning HTTP 200.

## Follow-Ups

This PR is stacked on #19 and should be reviewed after it. No additional code
follow-up is included in this body-only description normalization.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
