### PR TITLE
Ignore client-controlled Messenger debug fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-16
+
+- Removed the client-controlled Messenger `debug` reply bypass so valid signed
+  messages are processed regardless of unknown top-level fields.
+
 ## 2026-06-15
 
 - Anchored Make cleanup and verification to the loaded Makefile directory so

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   release their claim for recovery. Unsuccessful provider HTTP responses raise
   before reply content is accepted, allowing the webhook delivery to be
   retried. Signed webhook batches process up to 20 valid user messages in
-  payload order. Messenger POST bodies larger than 1 MiB are rejected with HTTP
+  payload order. Unknown top-level Messenger fields cannot suppress valid replies.
+  Messenger POST bodies larger than 1 MiB are rejected with HTTP
   413 before signature verification or JSON parsing. Generated responses that
   fail moderation use a reviewed generic fallback instead of failing a request.
   Messenger GET verification requires the exact `subscribe` mode after token

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,6 +59,7 @@ message-ID claim so a later provider delivery can retry the outbound reply.
 Each signed webhook processes at most 20 valid user messages in payload order,
 limiting outbound reply amplification while preserving per-message replay
 claims and failure release.
+Unknown top-level fields, including `debug`, do not suppress valid Messenger replies.
 
 For web services, APIs, sockets, or scraping workflows, prioritize reports involving authentication bypass, authorization errors, injection, server-side request forgery, unsafe deserialization, credential leakage, data exposure, or denial-of-service conditions. Use test accounts and minimal proof-of-concept traffic only.
 

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,7 @@ Priority:
 - Suppress duplicate Messenger replies from retried message IDs with bounded
   process-local state
 - Process Messenger message batches in order with a fixed per-webhook cap
+- Keep Messenger reply behavior independent of client-controlled debug fields
 - Fail Messenger replies on provider HTTP errors so webhook retries remain
   recoverable
 - Reject empty web chat queries before response generation

--- a/app.py
+++ b/app.py
@@ -127,16 +127,15 @@ def messenger_post():
         return "ok"
 
     # send message to get bot
-    if not data.get('debug'):
-        for sender, message, message_id in messages:
-            if message_id and not recent_messenger_message_ids.claim(message_id):
-                continue
-            try:
-                messenger_reply(sender, message)
-            except Exception:
-                if message_id:
-                    recent_messenger_message_ids.release(message_id)
-                raise
+    for sender, message, message_id in messages:
+        if message_id and not recent_messenger_message_ids.claim(message_id):
+            continue
+        try:
+            messenger_reply(sender, message)
+        except Exception:
+            if message_id:
+                recent_messenger_message_ids.release(message_id)
+            raise
 
     # must send back response quickly
     return "ok"

--- a/bot_tests.py
+++ b/bot_tests.py
@@ -128,8 +128,9 @@ class TestFacebook(unittest.TestCase):
         """
         Setup the data for the test.
         """
+        app.recent_messenger_message_ids = app.RecentMessageIds(
+            app.MAX_RECENT_MESSENGER_MESSAGE_IDS)
         self.data = {'object': 'page',
-                     'debug': True,
                      'entry': [{'id': u'1115484138511624',
                                 'time': 1467905719502,
                                 'messaging': [{'message': {'seq': 159,
@@ -145,8 +146,32 @@ class TestFacebook(unittest.TestCase):
         """
         A test with a sample payload for the messenger bot.
         """
-        r = self.post_signed_json(self.data)
+        calls = []
+        original_reply = app.messenger_reply
+        app.messenger_reply = lambda sender, message: calls.append(
+            (sender, message))
+        try:
+            r = self.post_signed_json(self.data)
+        finally:
+            app.messenger_reply = original_reply
+
         self.assertEqual(r.status_int, 200)
+        self.assertEqual(calls, [(self.user_id, 'testing 123')])
+
+    def test_facebook_debug_field_does_not_suppress_reply(self):
+        calls = []
+        data = dict(self.data)
+        data['debug'] = True
+        original_reply = app.messenger_reply
+        app.messenger_reply = lambda sender, message: calls.append(
+            (sender, message))
+        try:
+            r = self.post_signed_json(data)
+        finally:
+            app.messenger_reply = original_reply
+
+        self.assertEqual(r.status_int, 200)
+        self.assertEqual(calls, [(self.user_id, 'testing 123')])
 
     def test_facebook_response(self):
         """
@@ -360,10 +385,19 @@ class TestFacebook(unittest.TestCase):
         self.assertEqual(r.status_int, 403)
 
     def test_facebook_webhook_accepts_json_content_type_parameters(self):
-        r = self.post_signed_json(
-            self.data,
-            content_type='Application/JSON; charset=UTF-8')
+        calls = []
+        original_reply = app.messenger_reply
+        app.messenger_reply = lambda sender, message: calls.append(
+            (sender, message))
+        try:
+            r = self.post_signed_json(
+                self.data,
+                content_type='Application/JSON; charset=UTF-8')
+        finally:
+            app.messenger_reply = original_reply
+
         self.assertEqual(r.status_int, 200)
+        self.assertEqual(calls, [(self.user_id, 'testing 123')])
 
     def test_facebook_webhook_rejects_non_json_content_type(self):
         body = json.dumps(self.data).encode('utf-8')

--- a/docs/plans/2026-06-16-messenger-debug-field.md
+++ b/docs/plans/2026-06-16-messenger-debug-field.md
@@ -1,0 +1,35 @@
+# Ignore Client-Controlled Messenger Debug Fields
+
+## Status: Planned
+
+## Context
+
+The Messenger POST handler treats a top-level `debug` value in the signed JSON
+body as a command to suppress every outbound reply. That field exists only to
+support tests, but it is part of the external webhook request contract and can
+silently acknowledge otherwise valid messages without processing them.
+
+## Requirements
+
+- Process valid Messenger messages regardless of unknown top-level `debug`
+  fields.
+- Preserve signature, content-type, size, page-object, echo, replay, batch,
+  timeout, and provider-status behavior.
+- Replace payload-controlled test suppression with explicit reply stubbing.
+- Add dependency-free and Bottle/WebTest regressions plus mutation-sensitive
+  source, guidance, registration, and completed-plan contracts.
+
+## Scope Boundaries
+
+- Do not change Messenger authentication, endpoints, tokens, reply payloads,
+  replay IDs, or batch limits.
+- Do not merge or close stacked pull requests without owner authorization.
+
+## Verification
+
+- Run focused debug-field contracts and the full repository/external
+  `make check` gates with explicit timeouts.
+- Reject mutations that restore payload suppression, remove runtime tests,
+  weaken guidance, unregister the focused check, or reopen the plan.
+- Audit the exact diff, generated artifacts, conflicts, file modes, and
+  credential-like additions before committing.

--- a/docs/plans/2026-06-16-messenger-debug-field.md
+++ b/docs/plans/2026-06-16-messenger-debug-field.md
@@ -1,6 +1,6 @@
 # Ignore Client-Controlled Messenger Debug Fields
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -33,3 +33,28 @@ silently acknowledge otherwise valid messages without processing them.
   weaken guidance, unregister the focused check, or reopen the plan.
 - Audit the exact diff, generated artifacts, conflicts, file modes, and
   credential-like additions before committing.
+
+## Work Completed
+
+- Removed request-body `debug` branching from the Messenger POST handler.
+- Replaced payload-controlled test suppression with explicit reply stubs.
+- Added dependency-free and Bottle/WebTest regressions proving unknown
+  top-level fields do not suppress valid replies.
+- Added source, documentation, registration, and completed-plan contracts.
+
+## Verification Completed
+
+- `python3 -m py_compile app.py bot_tests.py scripts/check_valleybot_contracts.py`
+- Focused dependency-free debug-field contracts passed.
+- Focused Bottle/WebTest regression passed in an isolated environment created
+  from the exact pinned `requirements.txt`.
+- The first full Bottle run exposed shared replay-cache state between the new
+  positive regression and the sample webhook test; `TestFacebook.setUp` now
+  creates a fresh bounded replay cache for every case.
+- The second run exposed a content-type test that implicitly relied on payload
+  suppression; it now stubs reply delivery explicitly.
+- Repository and external-directory non-cleaning `make verify` passed all 55
+  dependency-free checks and 31 Bottle/WebTest cases with the pinned runtime.
+- Five isolated mutations were rejected for payload suppression restoration,
+  Bottle regression removal, dependency-free test unregistration, README
+  guidance removal, and stale plan status.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Dependency-free route contract checks for the legacy Bottle app."""
+import ast
 import importlib.util
 import hashlib
 import hmac
@@ -84,6 +85,9 @@ MAKEFILE_LOCATION_ROOT_PLAN_PATH = (
 )
 MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-15-messenger-reply-http-status.md"
+)
+MESSENGER_DEBUG_FIELD_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-16-messenger-debug-field.md"
 )
 
 
@@ -249,6 +253,23 @@ def assert_completed_plan(path, label):
     assert_true("make check" in plan_text, "{0} plan must document make check verification".format(label))
 
 
+def registered_main_tests(source):
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            for statement in node.body:
+                if (
+                        isinstance(statement, ast.Assign)
+                        and any(isinstance(target, ast.Name) and target.id == "tests"
+                                for target in statement.targets)
+                        and isinstance(statement.value, (ast.List, ast.Tuple))):
+                    return {
+                        element.id for element in statement.value.elts
+                        if isinstance(element, ast.Name)
+                    }
+    return set()
+
+
 def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(WEBHOOK_PLAN_PATH, "webhook hardening")
     assert_completed_plan(STANDALONE_SLACK_PLAN_PATH, "standalone Slack token")
@@ -275,6 +296,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_CHALLENGE_ESCAPE_PLAN_PATH, "Messenger challenge escaping")
     assert_completed_plan(MAKEFILE_LOCATION_ROOT_PLAN_PATH, "Makefile location root")
     assert_completed_plan(MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH, "Messenger reply HTTP status")
+    assert_completed_plan(MESSENGER_DEBUG_FIELD_PLAN_PATH, "Messenger debug field handling")
 
 
 def test_runtime_and_ci_contracts():
@@ -575,9 +597,9 @@ def test_messenger_verification_mode_source_contracts():
         "test_facebook_challenge_requires_subscribe_mode" in runtime_tests,
         "Bottle/WebTest must retain invalid Messenger mode coverage",
     )
-    main_source = checker_source.split("def main():", 1)[1]
     assert_true(
-        "\n        test_messenger_verification_requires_exact_subscribe_mode,\n" in main_source,
+        "test_messenger_verification_requires_exact_subscribe_mode"
+        in registered_main_tests(checker_source),
         "dependency-free Messenger mode coverage must remain registered",
     )
     guidance = "Messenger GET verification requires the exact `subscribe` mode"
@@ -835,7 +857,7 @@ def test_messenger_post_applies_replay_claims_per_batch_message():
     )
 
 
-def test_messenger_post_debug_batch_suppresses_all_replies():
+def test_messenger_post_debug_field_does_not_suppress_replies():
     app, request, _response, requests = load_app()
     request.json = messenger_batch_payload([
         messenger_event("user-1", "first", "mid-debug-1"),
@@ -844,7 +866,39 @@ def test_messenger_post_debug_batch_suppresses_all_replies():
 
     app.messenger_post()
 
-    assert_equal(requests.calls, [], "debug Messenger batch replies")
+    assert_equal(len(requests.calls), 2, "debug-field Messenger batch reply count")
+
+
+def test_messenger_debug_field_source_contracts():
+    source = (ROOT / "app.py").read_text(encoding="utf-8")
+    runtime_tests = (ROOT / "bot_tests.py").read_text(encoding="utf-8")
+    checker_source = Path(__file__).read_text(encoding="utf-8")
+
+    assert_true(
+        "data.get('debug')" not in source and 'data.get("debug")' not in source,
+        "Messenger request bodies must not control reply suppression",
+    )
+    assert_true(
+        "test_facebook_debug_field_does_not_suppress_reply" in runtime_tests,
+        "Bottle/WebTest must cover client-controlled debug fields",
+    )
+    assert_true(
+        "test_messenger_post_debug_field_does_not_suppress_replies"
+        in registered_main_tests(checker_source),
+        "dependency-free debug-field coverage must remain registered",
+    )
+
+    docs = {
+        "README.md": "Unknown top-level Messenger fields cannot suppress valid replies",
+        "SECURITY.md": "Unknown top-level fields, including `debug`, do not suppress valid Messenger replies",
+        "VISION.md": "Keep Messenger reply behavior independent of client-controlled debug fields",
+        "CHANGES.md": "Removed the client-controlled Messenger `debug` reply bypass",
+    }
+    for relative_path, phrase in docs.items():
+        assert_true(
+            phrase in (ROOT / relative_path).read_text(encoding="utf-8"),
+            "{0} must document Messenger debug-field handling".format(relative_path),
+        )
 
 
 def test_messenger_post_releases_only_failing_batch_claim():
@@ -1348,7 +1402,8 @@ def main():
         test_messenger_post_processes_valid_batch_in_payload_order,
         test_messenger_post_caps_valid_batch,
         test_messenger_post_applies_replay_claims_per_batch_message,
-        test_messenger_post_debug_batch_suppresses_all_replies,
+        test_messenger_post_debug_field_does_not_suppress_replies,
+        test_messenger_debug_field_source_contracts,
         test_messenger_post_releases_only_failing_batch_claim,
         test_messenger_post_suppresses_replayed_message_ids,
         test_messenger_post_preserves_messages_without_ids,


### PR DESCRIPTION
## Summary

Process valid signed Messenger messages independently of unknown client-controlled debug fields, while keeping test-only reply suppression outside production payload handling.

## Baseline

An otherwise valid Messenger payload could influence reply behavior through a top-level `debug` field, coupling production processing to client-controlled test behavior.

## Improvements

- process valid signed Messenger messages regardless of unknown top-level `debug` fields
- replace payload-controlled test suppression with explicit reply stubs and isolated replay fixtures
- add dependency-free, Bottle/WebTest, source, documentation, and completed-plan contracts

## Validation

- 55 dependency-free contract tests
- 31 Bottle/WebTest cases in an isolated environment from pinned `requirements.txt`
- repository and external-directory non-cleaning `make verify`
- five isolated mutations rejected
- exact head `926b07bf72053d266121dac6ddafc8211a5c34b4`: all 11 observed hosted checks succeeded

## Risk

The broad-cleaning wrapper was not run under workspace policy, and this change is stacked on PR #20. Runtime behavior still depends on the preceding verification-mode change landing first.

## Follow-Ups

- review and land PR #20 before this stacked change
- retain explicit reply stubs for future webhook tests instead of adding payload-controlled suppression
- continue bounded exact-head observation if the branch or hosted status changes

## Workspace Note

The broad-cleaning `make check` wrapper was not used because workspace policy forbids broad cleanup. Its complete `make verify` payload passed from both working directories, and only explicit generated bytecode paths were removed.

## Stack

This PR targets `lfg/valleybot-messenger-verification-mode-20260616` and should be reviewed after PR #20.

> Generated with [Codex](https://openai.com/codex/).
