### PR TITLE
fix: verify Slack requests with signing secrets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@
 
 ## Safety and gotchas
 
-- `SLACK_TOKEN` configures the Slack integration.
+- `SLACK_SIGNING_SECRET` configures Slack signing secret verification; unsigned,
+  stale, future, or tampered requests are rejected before bot execution.
 - `MESSENGER_TOKEN` configures Facebook Messenger API replies.
 - `MESSENGER_VERIFY_TOKEN` configures Messenger webhook verification; it falls back to `MESSENGER_TOKEN` for older deployments.
 - `REQUEST_TIMEOUT` optionally overrides outbound Messenger request timeout seconds; invalid, non-finite, or non-positive values fall back to `5.0`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## 2026-06-16
 
+- Replaced deprecated Slack payload-token checks with Slack signing secret
+  verification, exact-body HMAC, five-minute timestamp freshness, and signed
+  API Gateway base64-body handling across both entry points.
 - Removed the client-controlled Messenger `debug` reply bypass so valid signed
   messages are processed regardless of unknown top-level fields.
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ PYTHON_FILES := \
 	bot_tests.py \
 	config.py \
 	settings.py \
+	slack_auth.py \
 	slack.py \
 	scripts/check_valleybot_contracts.py
 
@@ -27,7 +28,7 @@ prepare-corpora:
 
 test: prepare-corpora
 	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(ROOT)/scripts/check_valleybot_contracts.py"
-	cd "$(ROOT)" && env SLACK_TOKEN=test-slack-token MESSENGER_TOKEN=test-page-token MESSENGER_VERIFY_TOKEN=test-verify-token $(PYTHON) -m unittest bot_tests
+	cd "$(ROOT)" && env SLACK_SIGNING_SECRET=test-slack-signing-secret MESSENGER_TOKEN=test-page-token MESSENGER_VERIFY_TOKEN=test-verify-token $(PYTHON) -m unittest bot_tests
 
 build: lint
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 ## Testing and Verification
 
 - `make verify` runs syntax checks and dependency-free Messenger and Slack
-  route contract checks, including Slack command token validation and Slack
+  route contract checks, including Slack signing secret verification and Slack
   command text validation, web chat text validation, web template escaping, bot
   JSON request validation, bot conversation log privacy, plus request timeout
   parsing checks. Slack command text, Messenger webhook object type, Messenger
@@ -98,7 +98,10 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 ## Configuration and Secrets
 
-- `SLACK_TOKEN` configures the Slack integration.
+- `SLACK_SIGNING_SECRET` configures Slack signing secret verification. Both
+  entry points reject unsigned, stale, future, or tampered request bodies
+  before bot execution and cap raw bodies at 1 MiB; the deprecated payload
+  verification token is not used.
 - `MESSENGER_TOKEN` configures Facebook Messenger API replies.
 - `MESSENGER_VERIFY_TOKEN` configures Messenger webhook verification; it falls back to `MESSENGER_TOKEN` for older deployments.
 - `MESSENGER_APP_SECRET` is required to validate the `X-Hub-Signature-256`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,9 +67,11 @@ Messenger webhook events should only generate bot replies when sender IDs and
 message text are textual and nonblank. Non-message, blank, or non-text events
 should be acknowledged without response generation.
 
-Slack command events should only generate bot replies after token validation
-and when command text is textual and nonblank. Missing, blank, or non-text
-command values should return the existing missing-text response.
+Slack signing secret verification covers the exact raw request body and a
+five-minute timestamp window for both entry points. Unsigned, stale, future,
+tampered, or larger-than-1-MiB Slack commands must fail before bot execution;
+the deprecated payload verification token is not an authentication fallback.
+Authenticated command text must still be textual and nonblank.
 
 ## Dependency and Supply Chain Security
 

--- a/VISION.md
+++ b/VISION.md
@@ -15,6 +15,7 @@ The current focus is:
 Priority:
 
 - Keep the service on supported Python 3 and current audited dependencies
+- Require Slack signing secret verification before command execution
 - Require authenticated Messenger POST payloads before event parsing
 - Bound unauthenticated Messenger request bodies before signature verification
 - Run the complete runtime suite across supported Python versions in CI

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import requests
 import settings
+from slack_auth import MAX_SLACK_REQUEST_BYTES, verify_slack_request
 
 debug(os.environ.get("BOTTLE_DEBUG", "").strip().lower() == "true")
 
@@ -51,8 +52,23 @@ def slack_handler():
     """
     Handler for slack
     """
-    token = request.forms.get('token')
-    if not secure_compare(token, settings.slack_token):
+    content_length = getattr(request, "content_length", None)
+    if content_length is not None and content_length > MAX_SLACK_REQUEST_BYTES:
+        response.status = 413
+        return "payload too large"
+    raw_body = request.body.read(MAX_SLACK_REQUEST_BYTES + 1)
+    if len(raw_body) > MAX_SLACK_REQUEST_BYTES:
+        response.status = 413
+        return "payload too large"
+    try:
+        request.body.seek(0)
+    except (AttributeError, IOError):
+        pass
+    if not verify_slack_request(
+            raw_body,
+            request.headers.get("X-Slack-Request-Timestamp"),
+            request.headers.get("X-Slack-Signature"),
+            settings.slack_signing_secret):
         response.status = 403
         return "forbidden"
 

--- a/bot_tests.py
+++ b/bot_tests.py
@@ -2,8 +2,10 @@ import unittest
 import os
 import hashlib
 import hmac
+import time
+from urllib.parse import urlencode
 
-os.environ.setdefault('SLACK_TOKEN', 'test-slack-token')
+os.environ.setdefault('SLACK_SIGNING_SECRET', 'test-slack-signing-secret')
 os.environ.setdefault('MESSENGER_TOKEN', 'test-page-token')
 os.environ.setdefault('MESSENGER_VERIFY_TOKEN', 'test-verify-token')
 os.environ.setdefault('MESSENGER_APP_SECRET', 'test-app-secret')
@@ -99,25 +101,86 @@ class TestBottleApp(unittest.TestCase):
 
 
 class TestSlack(unittest.TestCase):
+    def post_signed_slack(self, text, timestamp=None, signature=None,
+                          expect_errors=False):
+        body = urlencode({'text': text})
+        timestamp = str(int(time.time()) if timestamp is None else timestamp)
+        if signature is None:
+            base = 'v0:{0}:{1}'.format(timestamp, body).encode('utf-8')
+            signature = 'v0=' + hmac.new(
+                app.settings.slack_signing_secret.encode('utf-8'),
+                base,
+                hashlib.sha256).hexdigest()
+        return test_app.post(
+            '/slack',
+            body,
+            headers={
+                'X-Slack-Request-Timestamp': timestamp,
+                'X-Slack-Signature': signature,
+            },
+            content_type='application/x-www-form-urlencoded',
+            expect_errors=expect_errors)
+
     def test_slack(self):
         """
         A simple test for the slackbot.
         """
-        response = test_app.post('/slack',
-                                 {'text': 'do you work in finance',
-                                  'token': app.settings.slack_token})
+        response = self.post_signed_slack('do you work in finance')
         self.assertEqual(response.status_int, 200)
         self.assertTrue(len(response.body) >= 1)
 
-    def test_slack_rejects_bad_token(self):
+    def test_slack_rejects_bad_signature_without_bot_call(self):
         """
-        Slack requests must include the configured verification token.
+        Slack requests must include a valid signing-secret signature.
         """
-        response = test_app.post('/slack',
-                                 {'text': 'do you work in finance',
-                                  'token': 'bad-token'},
-                                 expect_errors=True)
+        original_respond = app.bot.respond
+        calls = []
+        app.bot.respond = lambda text: calls.append(text)
+        try:
+            response = self.post_signed_slack(
+                'do you work in finance',
+                signature='v0=' + ('0' * 64),
+                expect_errors=True)
+        finally:
+            app.bot.respond = original_respond
         self.assertEqual(response.status_int, 403)
+        self.assertEqual(calls, [])
+
+    def test_slack_rejects_stale_timestamp(self):
+        response = self.post_signed_slack(
+            'do you work in finance',
+            timestamp=int(time.time()) - 301,
+            expect_errors=True)
+
+        self.assertEqual(response.status_int, 403)
+
+    def test_slack_rejects_malformed_timestamp(self):
+        response = self.post_signed_slack(
+            'do you work in finance',
+            timestamp='not-a-time',
+            expect_errors=True)
+
+        self.assertEqual(response.status_int, 403)
+
+    def test_slack_rejects_oversized_body_before_bot_call(self):
+        original_respond = app.bot.respond
+        calls = []
+        app.bot.respond = lambda text: calls.append(text)
+        try:
+            response = test_app.post(
+                '/slack',
+                b'x' * (app.MAX_SLACK_REQUEST_BYTES + 1),
+                headers={
+                    'X-Slack-Request-Timestamp': str(int(time.time())),
+                    'X-Slack-Signature': 'v0=' + ('0' * 64),
+                },
+                content_type='application/x-www-form-urlencoded',
+                expect_errors=True)
+        finally:
+            app.bot.respond = original_respond
+
+        self.assertEqual(response.status_int, 413)
+        self.assertEqual(calls, [])
 
 
 class TestFacebook(unittest.TestCase):

--- a/docs/plans/2026-06-16-slack-signing-secret-verification.md
+++ b/docs/plans/2026-06-16-slack-signing-secret-verification.md
@@ -1,13 +1,13 @@
 # Slack Signing-Secret Verification
 
-status: in_progress
+status: completed
 
 ## Context
 
-Both Slack entry points authenticate a caller-controlled form or event `token`.
-Slack signing secrets provide request-body integrity and replay-resistant
-timestamps, while the legacy verification-token check cannot prove the body or
-request time and is no longer an adequate webhook boundary.
+Before this change, both Slack entry points authenticated a caller-controlled
+form or event `token`. Slack signing secrets provide request-body integrity and
+replay-resistant timestamps, while the legacy verification-token check cannot
+prove the body or request time and is no longer an adequate webhook boundary.
 
 ## Priority
 
@@ -23,8 +23,9 @@ the full response-generation path.
   `v0:{timestamp}:{raw_body}` base string using constant-time comparison.
 - R3. Reject missing, malformed, future, or older-than-five-minute timestamps
   before command processing.
-- R4. Preserve the exact raw request body for signature verification before
-  form parsing, including API Gateway base64 bodies for the event handler.
+- R4. Preserve a bounded exact raw request body for signature verification
+  before form parsing, including API Gateway base64 bodies for the event
+  handler; reject bodies larger than 1 MiB.
 - R5. Keep invalid requests fail-closed and prevent `bot.respond` calls.
 - R6. Preserve valid command-text trimming and current response behavior after
   authentication.
@@ -81,4 +82,16 @@ completed verification evidence.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- The complete dependency-free suite passed with 60 tests.
+- The complete pinned Bottle/WebTest suite passed with 34 tests.
+- The repository and external-directory `make verify` passed in an isolated
+  exact-requirements Python 3.12 environment.
+- An isolated disposable copy passed `make check`, including its cleanup
+  wrapper, without touching the preserved live worktree.
+- `uv pip check` passed for all 19 installed packages.
+- Ten isolated hostile mutations were rejected for the HMAC base string,
+  timestamp freshness, constant-time comparison, deprecated-token fallback,
+  base64 handling, Bottle and event body-size bounds, response-suppression
+  runtime coverage, guidance, and plan status.
+- Exact diff, generated-artifact, changed-line credential, dependency/workflow
+  drift, mode, and whitespace audits passed before commit.

--- a/docs/plans/2026-06-16-slack-signing-secret-verification.md
+++ b/docs/plans/2026-06-16-slack-signing-secret-verification.md
@@ -1,0 +1,84 @@
+# Slack Signing-Secret Verification
+
+status: in_progress
+
+## Context
+
+Both Slack entry points authenticate a caller-controlled form or event `token`.
+Slack signing secrets provide request-body integrity and replay-resistant
+timestamps, while the legacy verification-token check cannot prove the body or
+request time and is no longer an adequate webhook boundary.
+
+## Priority
+
+Close the unauthenticated command-execution boundary before adding more Slack
+features. A forged request currently reaches `bot.respond`, which can trigger
+the full response-generation path.
+
+## Requirements
+
+- R1. Require `SLACK_SIGNING_SECRET` for both Slack entry points; do not fall
+  back to the deprecated payload token.
+- R2. Verify `X-Slack-Signature` as HMAC-SHA256 over Slack's exact
+  `v0:{timestamp}:{raw_body}` base string using constant-time comparison.
+- R3. Reject missing, malformed, future, or older-than-five-minute timestamps
+  before command processing.
+- R4. Preserve the exact raw request body for signature verification before
+  form parsing, including API Gateway base64 bodies for the event handler.
+- R5. Keep invalid requests fail-closed and prevent `bot.respond` calls.
+- R6. Preserve valid command-text trimming and current response behavior after
+  authentication.
+- R7. Add dependency-free, Bottle/WebTest, source, documentation, and completed
+  plan contracts that reject hostile mutations.
+- R8. Do not log secrets, signatures, raw bodies, or command text; do not make
+  live Slack, Messenger, or external network requests.
+
+## Implementation Units
+
+### U1. Shared Slack verifier
+
+**File:** `slack_auth.py`
+
+Implement one dependency-free verifier with an injectable clock, strict
+timestamp parsing/freshness, exact bytes handling, versioned signature format,
+and constant-time comparison.
+
+### U2. Bottle and event entry points
+
+**Files:** `app.py`, `slack.py`, `settings.py`
+
+Read the signing secret from configuration, verify headers and raw bytes before
+form/event command extraction, decode API Gateway base64 bodies where declared,
+and remove payload-token authorization.
+
+### U3. Maintained verification and guidance
+
+**Files:** `bot_tests.py`, `scripts/check_valleybot_contracts.py`, `README.md`,
+`SECURITY.md`, `VISION.md`, `CHANGES.md`, and this plan.
+
+Cover valid signatures, tampering, stale/future/malformed timestamps, missing
+configuration, base64 event bodies, response suppression, source ordering, and
+completed verification evidence.
+
+## Verification
+
+- Run focused dependency-free and Bottle/WebTest Slack signature cases.
+- Run the complete dependency-free and pinned runtime suites through repository
+  and external-directory Make gates.
+- Reject isolated mutations for HMAC input, freshness, constant-time compare,
+  deprecated-token fallback, base64 handling, response suppression, guidance,
+  and plan status.
+- Audit the exact diff, generated artifacts, changed lines for credentials,
+  dependency/workflow drift, file modes, and whitespace before commit.
+
+## Scope Boundaries
+
+- Do not change Messenger behavior, dependencies, workflows, or bot response
+  selection.
+- Do not add a replay database or background queue; the signed timestamp window
+  is the bounded replay protection in this change.
+- Do not accept unsigned requests for compatibility.
+
+## Verification Completed
+
+Pending implementation and validation.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Dependency-free route contract checks for the legacy Bottle app."""
 import ast
+import base64
 import importlib.util
 import hashlib
 import hmac
@@ -8,7 +9,9 @@ import io
 import json
 import os
 import sys
+import time
 import types
+from urllib.parse import urlencode
 from pathlib import Path
 
 
@@ -89,6 +92,9 @@ MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH = (
 MESSENGER_DEBUG_FIELD_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-16-messenger-debug-field.md"
 )
+SLACK_SIGNING_SECRET_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-16-slack-signing-secret-verification.md"
+)
 
 
 class FakeBottle:
@@ -162,7 +168,7 @@ def install_stubs():
     bot.respond = respond
 
     settings = types.ModuleType("settings")
-    settings.slack_token = "slack-secret"
+    settings.slack_signing_secret = "slack-signing-secret"
     settings.messenger_token = "page-token"
     settings.messenger_verify_token = "verify-secret"
     settings.messenger_app_secret = "app-secret"
@@ -190,6 +196,41 @@ def load_slack_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module, sys.modules["bot"]
+
+
+def slack_signature(body, timestamp, secret="slack-signing-secret"):
+    base = "v0:{0}:{1}".format(timestamp, body).encode("utf-8")
+    return "v0=" + hmac.new(
+        secret.encode("utf-8"), base, hashlib.sha256
+    ).hexdigest()
+
+
+def configure_slack_request(request, text, timestamp=None, signature=None):
+    timestamp = str(int(time.time()) if timestamp is None else timestamp)
+    body = urlencode({"text": text})
+    request.body = io.BytesIO(body.encode("utf-8"))
+    request.forms = {"text": text}
+    request.headers = {
+        "X-Slack-Request-Timestamp": timestamp,
+        "X-Slack-Signature": signature or slack_signature(body, timestamp),
+    }
+    return body, timestamp
+
+
+def signed_slack_event(text, timestamp="1000", base64_encoded=False):
+    body = urlencode({"text": text})
+    event_body = (
+        base64.b64encode(body.encode("utf-8")).decode("ascii")
+        if base64_encoded else body
+    )
+    return {
+        "headers": {
+            "X-Slack-Request-Timestamp": timestamp,
+            "X-Slack-Signature": slack_signature(body, timestamp),
+        },
+        "body": event_body,
+        "isBase64Encoded": base64_encoded,
+    }
 
 
 def load_bot_module():
@@ -297,6 +338,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MAKEFILE_LOCATION_ROOT_PLAN_PATH, "Makefile location root")
     assert_completed_plan(MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH, "Messenger reply HTTP status")
     assert_completed_plan(MESSENGER_DEBUG_FIELD_PLAN_PATH, "Messenger debug field handling")
+    assert_completed_plan(SLACK_SIGNING_SECRET_PLAN_PATH, "Slack signing secret")
 
 
 def test_runtime_and_ci_contracts():
@@ -1279,34 +1321,39 @@ def test_moderation_review_guide_is_auditable():
     assert_true("mandatory human moderation checklist" in changes, "CHANGES must record moderation guide")
 
 
-def test_slack_command_requires_matching_token():
+def test_slack_command_requires_valid_signature():
     app, request, response, _requests = load_app()
 
-    request.forms = {"text": "do you work in finance", "token": "wrong"}
+    configure_slack_request(
+        request,
+        "do you work in finance",
+        signature="v0=" + ("0" * 64),
+    )
     response.status = 200
 
     body = app.slack_handler()
 
-    assert_true(body != "bot: do you work in finance", "invalid Slack token response")
-    assert_equal(response.status, 403, "invalid Slack token status")
+    assert_true(body != "bot: do you work in finance", "invalid Slack signature response")
+    assert_equal(response.status, 403, "invalid Slack signature status")
+    assert_equal(sys.modules["bot"].calls, [], "invalid signature must not call bot")
 
 
-def test_slack_command_accepts_matching_token():
+def test_slack_command_accepts_valid_signature():
     app, request, response, _requests = load_app()
 
-    request.forms = {"text": "do you work in finance", "token": "slack-secret"}
+    configure_slack_request(request, "do you work in finance")
     response.status = 200
 
     body = app.slack_handler()
 
-    assert_equal(body, "bot: do you work in finance", "valid Slack token response")
-    assert_equal(response.status, 200, "valid Slack token status")
+    assert_equal(body, "bot: do you work in finance", "valid Slack signature response")
+    assert_equal(response.status, 200, "valid Slack signature status")
 
 
 def test_slack_command_rejects_blank_text():
     app, request, response, _requests = load_app()
 
-    request.forms = {"text": "   ", "token": "slack-secret"}
+    configure_slack_request(request, "   ")
     response.status = 200
 
     body = app.slack_handler()
@@ -1319,7 +1366,8 @@ def test_slack_command_rejects_non_text_values():
     for text_value in ({"message": "hello"}, b"hello"):
         app, request, response, _requests = load_app()
 
-        request.forms = {"text": text_value, "token": "slack-secret"}
+        configure_slack_request(request, "placeholder")
+        request.forms = {"text": text_value}
         response.status = 200
 
         body = app.slack_handler()
@@ -1332,7 +1380,7 @@ def test_slack_command_rejects_non_text_values():
 def test_slack_command_trims_text_before_bot_call():
     app, request, response, _requests = load_app()
 
-    request.forms = {"text": "  do you work in finance  ", "token": "slack-secret"}
+    configure_slack_request(request, "  do you work in finance  ")
     response.status = 200
 
     body = app.slack_handler()
@@ -1341,41 +1389,189 @@ def test_slack_command_trims_text_before_bot_call():
     assert_equal(response.status, 200, "trimmed Slack text status")
 
 
-def test_standalone_slack_handler_requires_matching_token():
+def test_slack_command_rejects_stale_and_future_timestamps():
+    for timestamp in (int(time.time()) - 301, int(time.time()) + 1):
+        app, request, response, _requests = load_app()
+        body, timestamp_text = configure_slack_request(
+            request, "do you work in finance", timestamp=timestamp
+        )
+        request.headers["X-Slack-Signature"] = slack_signature(
+            body, timestamp_text
+        )
+        response.status = 200
+
+        result = app.slack_handler()
+
+        assert_equal(result, "forbidden", "stale/future Slack response")
+        assert_equal(response.status, 403, "stale/future Slack status")
+        assert_equal(sys.modules["bot"].calls, [], "stale/future request must not call bot")
+
+
+def test_slack_handlers_reject_oversized_bodies():
+    app, request, response, _requests = load_app()
+    request.content_length = app.MAX_SLACK_REQUEST_BYTES + 1
+    request.body = io.BytesIO(b"x")
+
+    body = app.slack_handler()
+
+    assert_equal(body, "payload too large", "oversized Bottle Slack response")
+    assert_equal(response.status, 413, "oversized Bottle Slack status")
+    assert_equal(sys.modules["bot"].calls, [], "oversized Bottle Slack request must not call bot")
+
+    slack, bot = load_slack_module()
+    oversized = "é" * 600000
+    event = {
+        "headers": {
+            "X-Slack-Request-Timestamp": "1000",
+            "X-Slack-Signature": slack_signature(oversized, "1000"),
+        },
+        "body": oversized,
+        "isBase64Encoded": False,
+    }
+
+    assert_equal(slack.slack_handler(event, now=1000), "payload too large", "oversized event Slack response")
+    assert_equal(bot.calls, [], "oversized event Slack request must not call bot")
+
+    max_encoded_length = ((app.MAX_SLACK_REQUEST_BYTES + 2) // 3) * 4
+    oversized_base64_event = {
+        "headers": {},
+        "body": "A" * (max_encoded_length + 1),
+        "isBase64Encoded": True,
+    }
+    assert_equal(
+        slack.slack_handler(oversized_base64_event, now=1000),
+        "payload too large",
+        "oversized encoded Slack response",
+    )
+
+
+def test_slack_signature_verifier_rejects_tampering_and_invalid_metadata():
+    from slack_auth import verify_slack_request
+
+    body = b"text=hello"
+    timestamp = "1000"
+    signature = slack_signature(body.decode("ascii"), timestamp)
+    assert_true(
+        verify_slack_request(
+            body, timestamp, signature, "slack-signing-secret", now=1000
+        ),
+        "valid Slack signature",
+    )
+    candidates = (
+        (b"text=tampered", timestamp, signature, "slack-signing-secret"),
+        (body, "not-a-time", signature, "slack-signing-secret"),
+        (body, "+1000", signature, "slack-signing-secret"),
+        (body, " 1000", signature, "slack-signing-secret"),
+        (body, "1001", slack_signature("text=hello", "1001"), "slack-signing-secret"),
+        (body, "699", slack_signature("text=hello", "699"), "slack-signing-secret"),
+        (body, timestamp, signature, ""),
+        (body, timestamp, "invalid", "slack-signing-secret"),
+    )
+    for candidate in candidates:
+        assert_true(
+            not verify_slack_request(*candidate, now=1000),
+            "invalid Slack signature metadata must fail closed",
+        )
+
+
+def test_slack_signing_secret_source_contracts():
+    app_source = (ROOT / "app.py").read_text(encoding="utf-8")
+    adapter_source = (ROOT / "slack.py").read_text(encoding="utf-8")
+    auth_source = (ROOT / "slack_auth.py").read_text(encoding="utf-8")
+    settings_source = (ROOT / "settings.py").read_text(encoding="utf-8")
+    runtime_tests = (ROOT / "bot_tests.py").read_text(encoding="utf-8")
+
+    for contract in (
+            'SLACK_SIGNATURE_VERSION = "v0"',
+            "SLACK_REQUEST_MAX_AGE_SECONDS = 5 * 60",
+            "if not timestamp.isdigit()",
+            'version = SLACK_SIGNATURE_VERSION.encode("ascii")',
+            'base = version + b":" + timestamp_bytes + b":" + raw_body',
+            'expected = SLACK_SIGNATURE_VERSION + "="',
+            "hmac.compare_digest(signature, expected)"):
+        assert_true(contract in auth_source, "missing Slack auth contract {0}".format(contract))
+    assert_true("request_time > current_time" in auth_source, "future Slack timestamps must fail")
+    assert_true("current_time - request_time > SLACK_REQUEST_MAX_AGE_SECONDS" in auth_source, "stale Slack timestamps must fail")
+    assert_true("request.body.read(MAX_SLACK_REQUEST_BYTES + 1)" in app_source, "Bottle Slack auth must bound the raw body")
+    assert_true(app_source.index("request.body.read(MAX_SLACK_REQUEST_BYTES + 1)") < app_source.index("request.forms.get('text')"), "Bottle Slack auth must precede form parsing")
+    assert_true("base64.b64decode(body, validate=True)" in adapter_source, "event Slack auth must decode declared base64 bodies")
+    assert_true("parse_qs(raw_body.decode(\"utf-8\")" in adapter_source, "event Slack handler must parse the verified body")
+    assert_true("SLACK_TOKEN" not in settings_source, "deprecated Slack token configuration must be removed")
+    assert_true("slack_token" not in app_source + adapter_source, "Slack token fallback must not remain")
+    assert_true("test_slack_rejects_bad_signature_without_bot_call" in runtime_tests, "Bottle runtime tests must cover signature rejection")
+
+    for path in ("AGENTS.md", "README.md", "SECURITY.md", "VISION.md", "CHANGES.md"):
+        content = (ROOT / path).read_text(encoding="utf-8")
+        assert_true("Slack signing secret" in content, "{0} must document Slack signing secret verification".format(path))
+
+    plan = SLACK_SIGNING_SECRET_PLAN_PATH.read_text(encoding="utf-8")
+    for evidence in (
+            "status: completed",
+            "complete dependency-free suite passed with 60 tests",
+            "complete pinned Bottle/WebTest suite passed with 34 tests",
+            "repository and external-directory `make verify` passed",
+            "Ten isolated hostile mutations were rejected"):
+        assert_true(evidence in plan, "Slack signing-secret plan must record {0}".format(evidence))
+
+
+def test_standalone_slack_handler_requires_valid_signature():
+    slack, bot = load_slack_module()
+    event = signed_slack_event("do you work in finance")
+    event["headers"]["X-Slack-Signature"] = "v0=" + ("0" * 64)
+
+    body = slack.slack_handler(event, now=1000)
+
+    assert_equal(body, "forbidden", "standalone invalid Slack signature response")
+    assert_equal(bot.calls, [], "standalone invalid signature must not call bot")
+
+
+def test_standalone_slack_handler_accepts_valid_signature():
     slack, bot = load_slack_module()
 
-    body = slack.slack_handler({"text": "do you work in finance", "token": "wrong"})
+    body = slack.slack_handler(
+        signed_slack_event("do you work in finance"), now=1000
+    )
 
-    assert_equal(body, "forbidden", "standalone invalid Slack token response")
-    assert_equal(bot.calls, [], "standalone invalid Slack token must not call bot")
-
-
-def test_standalone_slack_handler_accepts_matching_token():
-    slack, bot = load_slack_module()
-
-    body = slack.slack_handler({"text": "do you work in finance", "token": "slack-secret"})
-
-    assert_equal(body, "bot: do you work in finance", "standalone valid Slack token response")
-    assert_equal(bot.calls, ["do you work in finance"], "standalone valid Slack token bot call")
+    assert_equal(body, "bot: do you work in finance", "standalone valid Slack signature response")
+    assert_equal(bot.calls, ["do you work in finance"], "standalone valid Slack signature bot call")
 
 
 def test_standalone_slack_handler_rejects_blank_text():
     slack, bot = load_slack_module()
 
-    body = slack.slack_handler({"text": "   ", "token": "slack-secret"})
+    body = slack.slack_handler(signed_slack_event("   "), now=1000)
 
     assert_equal(body, "missing text", "standalone blank Slack text response")
     assert_equal(bot.calls, [], "standalone blank Slack text must not call bot")
 
 
-def test_standalone_slack_handler_rejects_non_text_values():
-    for text_value in ({"message": "hello"}, b"hello"):
-        slack, bot = load_slack_module()
+def test_standalone_slack_handler_rejects_missing_text():
+    slack, bot = load_slack_module()
+    body_text = "command=%2Fvalleybot"
+    event = signed_slack_event("placeholder")
+    event["body"] = body_text
+    event["headers"]["X-Slack-Signature"] = slack_signature(
+        body_text, "1000"
+    )
 
-        body = slack.slack_handler({"text": text_value, "token": "slack-secret"})
+    body = slack.slack_handler(event, now=1000)
 
-        assert_equal(body, "missing text", "standalone non-text Slack text response")
-        assert_equal(bot.calls, [], "standalone non-text Slack text must not call bot")
+    assert_equal(body, "missing text", "standalone missing Slack text response")
+    assert_equal(bot.calls, [], "standalone missing Slack text must not call bot")
+
+
+def test_standalone_slack_handler_accepts_signed_base64_body():
+    slack, bot = load_slack_module()
+
+    body = slack.slack_handler(
+        signed_slack_event(
+            "  do you work in finance  ", base64_encoded=True
+        ),
+        now=1000,
+    )
+
+    assert_equal(body, "bot: do you work in finance", "base64 Slack response")
+    assert_equal(bot.calls, ["do you work in finance"], "base64 Slack bot call")
 
 
 def main():
@@ -1426,15 +1622,20 @@ def main():
         test_bot_logging_avoids_private_message_text,
         test_filtered_responses_use_reviewed_fallback,
         test_moderation_review_guide_is_auditable,
-        test_slack_command_requires_matching_token,
-        test_slack_command_accepts_matching_token,
+        test_slack_command_requires_valid_signature,
+        test_slack_command_accepts_valid_signature,
         test_slack_command_rejects_blank_text,
         test_slack_command_rejects_non_text_values,
         test_slack_command_trims_text_before_bot_call,
-        test_standalone_slack_handler_requires_matching_token,
-        test_standalone_slack_handler_accepts_matching_token,
+        test_slack_command_rejects_stale_and_future_timestamps,
+        test_slack_handlers_reject_oversized_bodies,
+        test_slack_signature_verifier_rejects_tampering_and_invalid_metadata,
+        test_slack_signing_secret_source_contracts,
+        test_standalone_slack_handler_requires_valid_signature,
+        test_standalone_slack_handler_accepts_valid_signature,
         test_standalone_slack_handler_rejects_blank_text,
-        test_standalone_slack_handler_rejects_non_text_values,
+        test_standalone_slack_handler_rejects_missing_text,
+        test_standalone_slack_handler_accepts_signed_base64_body,
     ]
     for test in tests:
         test()

--- a/settings.py
+++ b/settings.py
@@ -13,7 +13,7 @@ def positive_float_from_env(name, default):
     return value
 
 
-slack_token = os.environ.get('SLACK_TOKEN', '')
+slack_signing_secret = os.environ.get('SLACK_SIGNING_SECRET', '')
 messenger_token = os.environ.get('MESSENGER_TOKEN', '')
 messenger_verify_token = os.environ.get('MESSENGER_VERIFY_TOKEN', messenger_token)
 messenger_app_secret = os.environ.get('MESSENGER_APP_SECRET', '')

--- a/slack.py
+++ b/slack.py
@@ -1,43 +1,61 @@
 import logging
-import hmac
+import base64
+from urllib.parse import parse_qs
 import settings
 import bot
+from slack_auth import MAX_SLACK_REQUEST_BYTES, verify_slack_request
 
-expected_token = settings.slack_token
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-def slack_handler(event):
-    token = event.get('token') if isinstance(event, dict) else None
-    if not secure_compare(token, expected_token):
+def slack_handler(event, now=None):
+    if not isinstance(event, dict):
         return "forbidden"
 
-    command_text = clean_text_value(event.get('text'))
+    headers = event.get("headers")
+    body = event.get("body")
+    if not isinstance(headers, dict) or not isinstance(body, str):
+        return "forbidden"
+
+    is_base64_encoded = event.get("isBase64Encoded") is True
+    max_encoded_length = ((MAX_SLACK_REQUEST_BYTES + 2) // 3) * 4
+    if len(body) > (
+            max_encoded_length if is_base64_encoded else MAX_SLACK_REQUEST_BYTES):
+        return "payload too large"
+
+    normalized_headers = {
+        str(name).lower(): value for name, value in headers.items()
+    }
+    try:
+        raw_body = (
+            base64.b64decode(body, validate=True)
+            if is_base64_encoded
+            else body.encode("utf-8")
+        )
+    except (UnicodeEncodeError, ValueError):
+        return "forbidden"
+    if len(raw_body) > MAX_SLACK_REQUEST_BYTES:
+        return "payload too large"
+
+    if not verify_slack_request(
+            raw_body,
+            normalized_headers.get("x-slack-request-timestamp"),
+            normalized_headers.get("x-slack-signature"),
+            settings.slack_signing_secret,
+            now=now):
+        return "forbidden"
+
+    try:
+        form = parse_qs(raw_body.decode("utf-8"), keep_blank_values=True)
+    except UnicodeDecodeError:
+        return "forbidden"
+    command_text = clean_text_value(form.get("text", [None])[0])
     if command_text is None:
         return "missing text"
 
     return bot.respond(command_text)
-
-
-def secure_compare(left, right):
-    if not (left and right):
-        return False
-
-    left = str(left)
-    right = str(right)
-    compare_digest = getattr(hmac, "compare_digest", None)
-    if compare_digest:
-        return compare_digest(left, right)
-
-    if len(left) != len(right):
-        return False
-
-    result = 0
-    for left_char, right_char in zip(left, right):
-        result |= ord(left_char) ^ ord(right_char)
-    return result == 0
 
 
 def clean_text_value(value):

--- a/slack_auth.py
+++ b/slack_auth.py
@@ -1,0 +1,37 @@
+import hashlib
+import hmac
+import time
+
+
+SLACK_SIGNATURE_VERSION = "v0"
+SLACK_REQUEST_MAX_AGE_SECONDS = 5 * 60
+MAX_SLACK_REQUEST_BYTES = 1024 * 1024
+
+
+def verify_slack_request(raw_body, timestamp, signature, signing_secret, now=None):
+    if not isinstance(raw_body, bytes):
+        return False
+    if not all(isinstance(value, str) and value for value in (
+            timestamp, signature, signing_secret)):
+        return False
+    if not timestamp.isdigit():
+        return False
+
+    request_time = int(timestamp)
+
+    current_time = int(time.time() if now is None else now)
+    if request_time > current_time:
+        return False
+    if current_time - request_time > SLACK_REQUEST_MAX_AGE_SECONDS:
+        return False
+
+    try:
+        timestamp_bytes = timestamp.encode("ascii")
+    except UnicodeEncodeError:
+        return False
+    version = SLACK_SIGNATURE_VERSION.encode("ascii")
+    base = version + b":" + timestamp_bytes + b":" + raw_body
+    expected = SLACK_SIGNATURE_VERSION + "=" + hmac.new(
+        signing_secret.encode("utf-8"), base, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(signature, expected)


### PR DESCRIPTION
## Summary

Slack commands can no longer reach the bot by supplying a caller-controlled verification token. Both entry points now authenticate the exact request body with Slack signing secrets before parsing or response generation.

## Baseline

The Bottle route and standalone event adapter trusted a form or event `token`, which did not prove body integrity or request freshness. A forged command could therefore reach `bot.respond`.

## Improvements

- Verify Slack `v0` HMAC-SHA256 signatures with constant-time comparison and strict five-minute timestamp freshness.
- Authenticate bounded raw bytes before form parsing, including declared API Gateway base64 bodies.
- Reject missing, malformed, future, stale, tampered, and larger-than-1-MiB requests before bot execution.
- Replace `SLACK_TOKEN` configuration with `SLACK_SIGNING_SECRET` and keep valid command trimming and response behavior.

## Validation

- `scripts/check_valleybot_contracts.py`: 60 dependency-free contracts passed.
- Pinned Python 3.12 Bottle/WebTest suite: 34 tests passed.
- Repository and external-directory `make verify` passed.
- A disposable copy passed the complete `make check` wrapper.
- `uv pip check` passed for all 19 installed packages.
- Ten isolated hostile mutations were rejected across signature input, freshness, constant-time comparison, token fallback, base64 decoding, size limits, response suppression, guidance, and plan completion.
- Exact diff, generated-artifact, credential-pattern, dependency/workflow drift, mode, and whitespace audits passed.

## Risk

A valid request can still be replayed within Slack's five-minute acceptance window because persistent request deduplication is outside this narrow change. Hosted push and pull-request checks are captured separately after PR creation.

## Follow-Ups

Keep this PR stacked on `lfg/valleybot-messenger-debug-field-20260616` and merge base-first only after explicit authorization and terminal canonical checks.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
