### PR TITLE
Suppress replayed Slack requests in each process

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-17
+
+- Suppressed repeated Slack signatures in each running process before a second
+  bot call, while releasing failed claims for retry recovery.
+
 ## 2026-06-16
 
 - Replaced deprecated Slack payload-token checks with Slack signing secret

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PYTHON_FILES := \
 	config.py \
 	settings.py \
 	slack_auth.py \
+	slack_replay.py \
 	slack.py \
 	scripts/check_valleybot_contracts.py
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
   entry points reject unsigned, stale, future, or tampered request bodies
   before bot execution and cap raw bodies at 1 MiB; the deprecated payload
   verification token is not used.
+- Verified commands use bounded process-local Slack signature claims so an
+  exact retry does not call the bot twice; separate processes still require a
+  shared replay store for global suppression.
 - `MESSENGER_TOKEN` configures Facebook Messenger API replies.
 - `MESSENGER_VERIFY_TOKEN` configures Messenger webhook verification; it falls back to `MESSENGER_TOKEN` for older deployments.
 - `MESSENGER_APP_SECRET` is required to validate the `X-Hub-Signature-256`
@@ -170,6 +173,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   messages without hiding later user messages in the same webhook payload.
 - See `docs/plans/2026-06-15-messenger-reply-http-status.md` for provider HTTP
   failure handling and replay-claim recovery.
+- See `docs/plans/2026-06-17-slack-request-replay-guard.md` for bounded
+  process-local Slack signature claims and failure recovery.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,6 +72,10 @@ five-minute timestamp window for both entry points. Unsigned, stale, future,
 tampered, or larger-than-1-MiB Slack commands must fail before bot execution;
 the deprecated payload verification token is not an authentication fallback.
 Authenticated command text must still be textual and nonblank.
+Bounded process-local Slack signature claims suppress exact retries before a
+second bot call and are released after processing failures. Separate workers,
+restarts, and evicted entries require a shared persistent replay store for
+global suppression.
 
 ## Dependency and Supply Chain Security
 

--- a/VISION.md
+++ b/VISION.md
@@ -16,6 +16,7 @@ Priority:
 
 - Keep the service on supported Python 3 and current audited dependencies
 - Require Slack signing secret verification before command execution
+- Suppress repeated Slack signatures with bounded process-local state
 - Require authenticated Messenger POST payloads before event parsing
 - Bound unauthenticated Messenger request bodies before signature verification
 - Run the complete runtime suite across supported Python versions in CI

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ import json
 import requests
 import settings
 from slack_auth import MAX_SLACK_REQUEST_BYTES, verify_slack_request
+from slack_replay import RecentSlackSignatures
 
 debug(os.environ.get("BOTTLE_DEBUG", "").strip().lower() == "true")
 
@@ -44,6 +45,7 @@ class RecentMessageIds(object):
 
 recent_messenger_message_ids = RecentMessageIds(
     MAX_RECENT_MESSENGER_MESSAGE_IDS)
+recent_slack_signatures = RecentSlackSignatures()
 
 
 # SLACK INTEGRATION
@@ -64,10 +66,11 @@ def slack_handler():
         request.body.seek(0)
     except (AttributeError, IOError):
         pass
+    slack_signature = request.headers.get("X-Slack-Signature")
     if not verify_slack_request(
             raw_body,
             request.headers.get("X-Slack-Request-Timestamp"),
-            request.headers.get("X-Slack-Signature"),
+            slack_signature,
             settings.slack_signing_secret):
         response.status = 403
         return "forbidden"
@@ -77,7 +80,13 @@ def slack_handler():
         response.status = 400
         return "missing text"
 
-    return bot.respond(command_text)
+    if not recent_slack_signatures.claim(slack_signature):
+        return "ok"
+    try:
+        return bot.respond(command_text)
+    except Exception:
+        recent_slack_signatures.release(slack_signature)
+        raise
 
 
 # FACEBOOK MESSENGER INTEGRATION

--- a/bot_tests.py
+++ b/bot_tests.py
@@ -101,6 +101,9 @@ class TestBottleApp(unittest.TestCase):
 
 
 class TestSlack(unittest.TestCase):
+    def setUp(self):
+        app.recent_slack_signatures = app.RecentSlackSignatures()
+
     def post_signed_slack(self, text, timestamp=None, signature=None,
                           expect_errors=False):
         body = urlencode({'text': text})
@@ -128,6 +131,40 @@ class TestSlack(unittest.TestCase):
         response = self.post_signed_slack('do you work in finance')
         self.assertEqual(response.status_int, 200)
         self.assertTrue(len(response.body) >= 1)
+
+    def test_slack_suppresses_replayed_signature(self):
+        original_respond = app.bot.respond
+        calls = []
+        app.bot.respond = lambda text: calls.append(text) or 'first response'
+        timestamp = int(time.time())
+        try:
+            first = self.post_signed_slack('replayed command', timestamp=timestamp)
+            second = self.post_signed_slack('replayed command', timestamp=timestamp)
+        finally:
+            app.bot.respond = original_respond
+
+        self.assertEqual(first.text, 'first response')
+        self.assertEqual(second.text, 'ok')
+        self.assertEqual(calls, ['replayed command'])
+
+    def test_slack_releases_signature_after_bot_failure(self):
+        original_respond = app.bot.respond
+        timestamp = int(time.time())
+
+        def fail(_text):
+            raise RuntimeError('bot failed')
+
+        app.bot.respond = fail
+        try:
+            failed = self.post_signed_slack(
+                'retry command', timestamp=timestamp, expect_errors=True)
+            self.assertEqual(failed.status_int, 500)
+            app.bot.respond = lambda text: 'recovered: ' + text
+            retry = self.post_signed_slack('retry command', timestamp=timestamp)
+        finally:
+            app.bot.respond = original_respond
+
+        self.assertEqual(retry.text, 'recovered: retry command')
 
     def test_slack_rejects_bad_signature_without_bot_call(self):
         """

--- a/docs/plans/2026-06-17-slack-request-replay-guard.md
+++ b/docs/plans/2026-06-17-slack-request-replay-guard.md
@@ -1,0 +1,95 @@
+# Slack Request Replay Guard
+
+status: completed
+
+## Context
+
+Slack signatures authenticate the exact body and reject timestamps outside a
+five-minute window, but the same valid signed request can still execute
+`bot.respond` repeatedly during that window. Slack retries make this a
+practical duplicate-execution path in both the Bottle and event handlers.
+
+## Requirements
+
+- R1. Claim a verified Slack signature before bot execution in both handlers.
+- R2. A repeated in-process signature must return a successful acknowledgement
+  without another `bot.respond` call.
+- R3. Release a claim when bot processing raises so a provider retry can
+  recover.
+- R4. Bound process-local signature state and make claim/release thread-safe.
+- R5. Preserve signature, timestamp, body-size, text-validation, and successful
+  first-request behavior.
+- R6. Document that separate processes or evicted entries still require a
+  shared persistent replay store for global suppression.
+- R7. Add registered dependency-free, Bottle/WebTest, source, documentation,
+  and completed-plan contracts with hostile mutation coverage.
+
+## Implementation Units
+
+### U1. Bounded signature claims
+
+**Files:** `slack_replay.py`, `app.py`, `slack.py`
+
+Add a dependency-free bounded claim set. Apply it after authentication and
+text validation but before bot execution, and release only failed processing
+claims.
+
+### U2. Runtime and static contracts
+
+**Files:** `bot_tests.py`, `scripts/check_valleybot_contracts.py`, `Makefile`
+
+Cover duplicate suppression, failure recovery, bounded eviction, ordering in
+both handlers, test registration, and completed plan evidence.
+
+### U3. Security guidance
+
+**Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`, this plan
+
+Record process-local replay suppression and its cross-process limitation.
+
+## Verification Plan
+
+- Run focused replay cases and the complete dependency-free suite.
+- Run repository and external-directory `make verify` without invoking the
+  live worktree's broad cleanup target.
+- Run full `make check` only in an isolated disposable copy.
+- Reject isolated mutations for Bottle and event claims, duplicate
+  acknowledgements, failure release, bounded eviction, registration,
+  documentation, and plan completion.
+- Audit the exact diff, generated artifacts, file modes, conflict markers, and
+  credential-like additions before commit.
+
+## Scope Boundaries
+
+- Do not add a database, queue, cache service, dependency, workflow change, or
+  live Slack request.
+- Do not claim cross-process or durable replay prevention.
+- Do not change Messenger behavior or bot response selection.
+
+## Work Completed
+
+- Added a 1,024-entry thread-safe process-local Slack signature claim set.
+- Claimed verified signatures after text validation and before bot execution in
+  both entry points, acknowledged duplicates without a second bot call, and
+  released claims after processing failures.
+- Added dependency-free, Bottle/WebTest, source-ordering, registration,
+  bounded-eviction, documentation, and completed-plan contracts.
+- Documented that workers, restarts, and evicted entries still require shared
+  persistent state for global replay suppression.
+
+## Verification Completed
+
+- Python compilation passed for the changed runtime and checker modules.
+- Six focused dependency-free replay, failure-release, eviction, ordering, and
+  registration cases passed.
+- Two focused Bottle/WebTest replay and failure-release cases passed in the
+  pinned Python 3.12 environment.
+- Repository-root and external-directory `make verify` passed with 66
+  dependency-free contract tests and 36 pinned Bottle/WebTest tests.
+- An isolated disposable copy passed the full cleanup-wrapped `make check`
+  without running broad cleanup in the preserved live worktree.
+- Nine independently restored hostile mutations were rejected for Bottle and
+  event claims, failure release, duplicate acknowledgement, bounded eviction,
+  registration, documentation, and plan completion.
+- `uv pip check --python /tmp/valleybot-clean-venv/bin/python` confirmed all 18
+  installed packages are compatible.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -95,6 +95,9 @@ MESSENGER_DEBUG_FIELD_PLAN_PATH = (
 SLACK_SIGNING_SECRET_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-16-slack-signing-secret-verification.md"
 )
+SLACK_REPLAY_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-17-slack-request-replay-guard.md"
+)
 
 
 class FakeBottle:
@@ -339,6 +342,14 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH, "Messenger reply HTTP status")
     assert_completed_plan(MESSENGER_DEBUG_FIELD_PLAN_PATH, "Messenger debug field handling")
     assert_completed_plan(SLACK_SIGNING_SECRET_PLAN_PATH, "Slack signing secret")
+    assert_completed_plan(SLACK_REPLAY_PLAN_PATH, "Slack request replay guard")
+    registered = registered_main_tests(
+        (ROOT / "scripts" / "check_valleybot_contracts.py").read_text(encoding="utf-8")
+    )
+    assert_true(
+        "test_slack_replay_source_contracts" in registered,
+        "Slack replay source contracts must remain registered",
+    )
 
 
 def test_runtime_and_ci_contracts():
@@ -1350,6 +1361,39 @@ def test_slack_command_accepts_valid_signature():
     assert_equal(response.status, 200, "valid Slack signature status")
 
 
+def test_slack_command_suppresses_replayed_signature():
+    app, request, response, _requests = load_app()
+    configure_slack_request(request, "replayed command", timestamp=int(time.time()))
+
+    first = app.slack_handler()
+    second = app.slack_handler()
+
+    assert_equal(first, "bot: replayed command", "first Slack replay response")
+    assert_equal(second, "ok", "duplicate Slack replay acknowledgement")
+    assert_equal(sys.modules["bot"].calls, ["replayed command"], "duplicate Slack bot calls")
+    assert_equal(response.status, 200, "duplicate Slack replay status")
+
+
+def test_slack_command_releases_replay_claim_after_failure():
+    app, request, _response, _requests = load_app()
+    configure_slack_request(request, "retry command", timestamp=int(time.time()))
+    original_respond = sys.modules["bot"].respond
+
+    def fail(_text):
+        raise RuntimeError("bot failed")
+
+    sys.modules["bot"].respond = fail
+    try:
+        app.slack_handler()
+        raise AssertionError("Slack bot failures must propagate")
+    except RuntimeError:
+        pass
+    finally:
+        sys.modules["bot"].respond = original_respond
+
+    assert_equal(app.slack_handler(), "bot: retry command", "Slack retry after bot failure")
+
+
 def test_slack_command_rejects_blank_text():
     app, request, response, _requests = load_app()
 
@@ -1536,6 +1580,106 @@ def test_standalone_slack_handler_accepts_valid_signature():
     assert_equal(bot.calls, ["do you work in finance"], "standalone valid Slack signature bot call")
 
 
+def test_standalone_slack_handler_suppresses_replayed_signature():
+    slack, bot = load_slack_module()
+    event = signed_slack_event("replayed command")
+
+    first = slack.slack_handler(event, now=1000)
+    second = slack.slack_handler(event, now=1000)
+
+    assert_equal(first, "bot: replayed command", "standalone first replay response")
+    assert_equal(second, "ok", "standalone duplicate replay acknowledgement")
+    assert_equal(bot.calls, ["replayed command"], "standalone duplicate bot calls")
+
+
+def test_standalone_slack_handler_releases_replay_claim_after_failure():
+    slack, bot = load_slack_module()
+    event = signed_slack_event("retry command")
+    original_respond = bot.respond
+
+    def fail(_text):
+        raise RuntimeError("bot failed")
+
+    bot.respond = fail
+    try:
+        slack.slack_handler(event, now=1000)
+        raise AssertionError("standalone Slack bot failures must propagate")
+    except RuntimeError:
+        pass
+    finally:
+        bot.respond = original_respond
+
+    assert_equal(
+        slack.slack_handler(event, now=1000),
+        "bot: retry command",
+        "standalone Slack retry after bot failure",
+    )
+
+
+def test_recent_slack_signatures_evicts_oldest_claim():
+    from slack_replay import RecentSlackSignatures
+
+    recent = RecentSlackSignatures(2)
+    assert_true(recent.claim("first"), "first Slack signature claim")
+    assert_true(recent.claim("second"), "second Slack signature claim")
+    assert_true(not recent.claim("first"), "duplicate Slack signature claim")
+    assert_true(recent.claim("third"), "third Slack signature claim")
+    assert_true(recent.claim("first"), "evicted Slack signature can be reclaimed")
+
+
+def test_slack_replay_source_contracts():
+    app_source = (ROOT / "app.py").read_text(encoding="utf-8")
+    adapter_source = (ROOT / "slack.py").read_text(encoding="utf-8")
+    replay_source = (ROOT / "slack_replay.py").read_text(encoding="utf-8")
+
+    for contract in (
+            "MAX_RECENT_SLACK_SIGNATURES = 1024",
+            "class RecentSlackSignatures(object):",
+            "with self._lock:",
+            "while len(self._signatures) > self.max_entries:",
+            "self._signatures.popitem(last=False)"):
+        assert_true(contract in replay_source, "missing Slack replay contract {0}".format(contract))
+
+    for source, label in ((app_source, "Bottle"), (adapter_source, "event")):
+        verify_position = source.index("if not verify_slack_request(")
+        text_position = source.index("command_text = clean_text_value", verify_position)
+        claim_position = source.index("recent_slack_signatures.claim(slack_signature)", text_position)
+        bot_position = source.index("bot.respond(command_text)", claim_position)
+        release_position = source.index("recent_slack_signatures.release(slack_signature)", bot_position)
+        assert_true(
+            verify_position < text_position < claim_position < bot_position < release_position,
+            "{0} Slack replay claim and release ordering".format(label),
+        )
+        assert_true(
+            'return "ok"' in source[claim_position:bot_position],
+            "{0} duplicate acknowledgement".format(label),
+        )
+
+    registered = registered_main_tests(
+        (ROOT / "scripts" / "check_valleybot_contracts.py").read_text(encoding="utf-8")
+    )
+    for test_name in (
+            "test_slack_command_suppresses_replayed_signature",
+            "test_slack_command_releases_replay_claim_after_failure",
+            "test_standalone_slack_handler_suppresses_replayed_signature",
+            "test_standalone_slack_handler_releases_replay_claim_after_failure",
+            "test_recent_slack_signatures_evicts_oldest_claim",
+            "test_slack_replay_source_contracts"):
+        assert_true(test_name in registered, "Slack replay test must remain registered: {0}".format(test_name))
+
+    docs = {
+        "README.md": "bounded process-local Slack signature claims",
+        "SECURITY.md": "Bounded process-local Slack signature claims",
+        "VISION.md": "Suppress repeated Slack signatures with bounded process-local state",
+        "CHANGES.md": "Suppressed repeated Slack signatures in each running process",
+    }
+    for relative_path, phrase in docs.items():
+        assert_true(
+            phrase in (ROOT / relative_path).read_text(encoding="utf-8"),
+            "{0} must document Slack replay suppression".format(relative_path),
+        )
+
+
 def test_standalone_slack_handler_rejects_blank_text():
     slack, bot = load_slack_module()
 
@@ -1624,6 +1768,8 @@ def main():
         test_moderation_review_guide_is_auditable,
         test_slack_command_requires_valid_signature,
         test_slack_command_accepts_valid_signature,
+        test_slack_command_suppresses_replayed_signature,
+        test_slack_command_releases_replay_claim_after_failure,
         test_slack_command_rejects_blank_text,
         test_slack_command_rejects_non_text_values,
         test_slack_command_trims_text_before_bot_call,
@@ -1631,8 +1777,12 @@ def main():
         test_slack_handlers_reject_oversized_bodies,
         test_slack_signature_verifier_rejects_tampering_and_invalid_metadata,
         test_slack_signing_secret_source_contracts,
+        test_slack_replay_source_contracts,
         test_standalone_slack_handler_requires_valid_signature,
         test_standalone_slack_handler_accepts_valid_signature,
+        test_standalone_slack_handler_suppresses_replayed_signature,
+        test_standalone_slack_handler_releases_replay_claim_after_failure,
+        test_recent_slack_signatures_evicts_oldest_claim,
         test_standalone_slack_handler_rejects_blank_text,
         test_standalone_slack_handler_rejects_missing_text,
         test_standalone_slack_handler_accepts_signed_base64_body,

--- a/slack.py
+++ b/slack.py
@@ -4,10 +4,12 @@ from urllib.parse import parse_qs
 import settings
 import bot
 from slack_auth import MAX_SLACK_REQUEST_BYTES, verify_slack_request
+from slack_replay import RecentSlackSignatures
 
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+recent_slack_signatures = RecentSlackSignatures()
 
 
 def slack_handler(event, now=None):
@@ -39,10 +41,11 @@ def slack_handler(event, now=None):
     if len(raw_body) > MAX_SLACK_REQUEST_BYTES:
         return "payload too large"
 
+    slack_signature = normalized_headers.get("x-slack-signature")
     if not verify_slack_request(
             raw_body,
             normalized_headers.get("x-slack-request-timestamp"),
-            normalized_headers.get("x-slack-signature"),
+            slack_signature,
             settings.slack_signing_secret,
             now=now):
         return "forbidden"
@@ -55,7 +58,13 @@ def slack_handler(event, now=None):
     if command_text is None:
         return "missing text"
 
-    return bot.respond(command_text)
+    if not recent_slack_signatures.claim(slack_signature):
+        return "ok"
+    try:
+        return bot.respond(command_text)
+    except Exception:
+        recent_slack_signatures.release(slack_signature)
+        raise
 
 
 def clean_text_value(value):

--- a/slack_replay.py
+++ b/slack_replay.py
@@ -1,0 +1,25 @@
+from collections import OrderedDict
+import threading
+
+
+MAX_RECENT_SLACK_SIGNATURES = 1024
+
+
+class RecentSlackSignatures(object):
+    def __init__(self, max_entries=MAX_RECENT_SLACK_SIGNATURES):
+        self.max_entries = max_entries
+        self._signatures = OrderedDict()
+        self._lock = threading.Lock()
+
+    def claim(self, signature):
+        with self._lock:
+            if signature in self._signatures:
+                return False
+            self._signatures[signature] = None
+            while len(self._signatures) > self.max_entries:
+                self._signatures.popitem(last=False)
+            return True
+
+    def release(self, signature):
+        with self._lock:
+            self._signatures.pop(signature, None)


### PR DESCRIPTION
## Summary

Historical pull request metadata normalized for engineering-bar traceability. The original description is preserved verbatim below.

## Baseline

This pull request predates the current standardized engineering-bar description format.

## Improvements

- Preserves the original code, commits, review state, and pull request state.
- Adds structured documentation headings only; no repository files or merge decisions change.

## Validation

- Confirmed pull request #23 remains closed at head `50a8dc719413713963d11383b02f04bc237fe4ae`.
- Confirmed this edit changes only the pull request description.

## Risk

No runtime or repository risk; this is metadata-only normalization.

## Follow-Ups

None required for this historical pull request.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because no repository or deployed runtime content changed.

## Original PR Description

## Summary
Suppress exact signed Slack retries with bounded process-local claims in both entry points.

## Why
A valid request could execute `bot.respond` repeatedly during the five-minute signature window.

## Implementation
Add a thread-safe 1,024-entry signature claim set, acknowledge completed duplicates without a second bot call, and release failed processing claims so retries can recover.

## Verification
- 66 dependency-free contract tests passed
- 36 pinned Bottle/WebTest tests passed
- repository and external-directory `make verify` passed
- isolated full `make check` passed
- 9 isolated hostile mutations were rejected
- `uv pip check` passed for 18 packages

## Risk
Suppression is process-local and bounded. Separate workers, restarts, and evicted entries still require shared persistent state for global replay prevention.

## Rollback
Revert commit `50a8dc7` to restore timestamp-only replay handling.
