### PR TITLE
docs: correct Messenger verify token guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,8 @@
 - `SLACK_SIGNING_SECRET` configures Slack signing secret verification; unsigned,
   stale, future, or tampered requests are rejected before bot execution.
 - `MESSENGER_TOKEN` configures Facebook Messenger API replies.
-- `MESSENGER_VERIFY_TOKEN` configures Messenger webhook verification; it falls back to `MESSENGER_TOKEN` for older deployments.
+- `MESSENGER_VERIFY_TOKEN` configures Messenger webhook verification; missing
+  values fail closed and never fall back to `MESSENGER_TOKEN`.
 - `REQUEST_TIMEOUT` optionally overrides outbound Messenger request timeout seconds; invalid, non-finite, or non-positive values fall back to `5.0`.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -1241,6 +1241,11 @@ def test_messenger_verify_token_missing_fails_closed_without_page_token_fallback
         "never fall back to `MESSENGER_TOKEN`" in readme,
         "README must document Messenger verify token fail-closed behavior",
     )
+    agent_guidance = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert_true(
+        "never fall back to `MESSENGER_TOKEN`" in agent_guidance,
+        "AGENTS.md must document Messenger verify token fail-closed behavior",
+    )
 
 
 def test_bot_json_request_rejects_invalid_or_blank_payloads():


### PR DESCRIPTION
## Summary

Historical pull request metadata normalized for engineering-bar traceability. The original description is preserved verbatim below.

## Baseline

This pull request predates the current standardized engineering-bar description format.

## Improvements

- Preserves the original code, commits, review state, and pull request state.
- Adds structured documentation headings only; no repository files or merge decisions change.

## Validation

- Confirmed pull request #25 remains merged at head `562f96a0f8e4654379eca5417969cebb449db91c`.
- Confirmed this edit changes only the pull request description.

## Risk

No runtime or repository risk; this is metadata-only normalization.

## Follow-Ups

None required for this historical pull request.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because no repository or deployed runtime content changed.

## Original PR Description

## Summary

Align the repository's agent guidance with the merged Messenger verification-token behavior and make the existing security contract enforce that guidance.

## Baseline

`settings.py`, the README, and runtime tests correctly require an independent `MESSENGER_VERIFY_TOKEN`, but `AGENTS.md` still claimed that a missing value falls back to `MESSENGER_TOKEN`. That instruction could lead future maintenance work to reintroduce the retired credential fallback.

## Changes

- document that a missing Messenger verify token fails closed and never uses the page access token
- extend the existing fail-closed contract to cover `AGENTS.md` as well as runtime settings and README guidance

## Validation

- isolated Python 3.12.8 environment with `PYTHONPATH` removed
- repository-root `make check`: 69 contracts, 5 hostile web-chat mutations, and 39 runtime tests passed
- external-directory `make -f .../Makefile ROOT=/nonexistent check`: same complete gate passed
- `uv pip check`: all 41 installed packages compatible
- `pip-audit -r requirements.txt`: no known vulnerabilities; the non-PyPI WebOb build remains explicitly unauditable
- `git diff --check` and credential-pattern screening passed

## Risk

This changes agent-facing documentation and its static regression contract only. Runtime Messenger behavior is unchanged.

