### PR TITLE
fix: guard NLTK resource paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+- Guarded NLTK resource loading against URL-encoded absolute and parent-path
+  traversal while preserving fixed TextBlob corpus names, with runtime and
+  static regressions for GHSA-p4gq-832x-fm9v.
+
 ## 2026-06-17
 
 - Limited public web-chat input to 1,000 trimmed Unicode characters before

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PYTHON_FILES := \
 	bot.py \
 	bot_tests.py \
 	config.py \
+	nltk_guard.py \
 	settings.py \
 	slack_auth.py \
 	slack_replay.py \

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Public `/bot` chat input is limited to 1,000 trimmed Unicode characters
   before TextBlob/NLTK response generation. This is a per-request input bound,
   not authentication, aggregate rate limiting, or an execution timeout.
+- URL-encoded NLTK resource paths are decoded and rejected when they resolve
+  to absolute or parent-traversing paths before corpus loading.
 - Verified Messenger GET challenges are HTML-escaped before response delivery,
   so hostile markup cannot become reflected page content.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -82,6 +82,12 @@ characters before TextBlob/NLTK processing. This limits per-request parser and
 tagger input but does not provide authentication, aggregate request-rate
 control, or a hard response-generation timeout.
 
+NLTK resource loads are wrapped by `nltk_guard.py`. The guard repeatedly
+decodes resource identifiers and rejects absolute or parent-traversing paths
+before `nltk.data.load()` runs, including URL-encoded variants covered by
+GHSA-p4gq-832x-fm9v. Keep user-controlled resource identifiers out of NLTK and
+retain the guard until an independently validated patched release is used.
+
 ## Dependency and Supply Chain Security
 
 Dependency updates should come from trusted package managers and should keep lockfiles in sync when lockfiles exist. Do not commit credentials, private keys, tokens, generated secrets, or machine-local configuration. If a vulnerability depends on a compromised package, typosquatting risk, insecure transitive dependency, or unsafe build step, include the package name, affected version, and the path through which it is used.

--- a/bot.py
+++ b/bot.py
@@ -7,6 +7,9 @@ import logging
 import os
 import config
 import nltk
+from nltk_guard import install_nltk_load_guard
+
+install_nltk_load_guard(nltk)
 nltk.data.path.append(os.getcwd() + '/nltk_data')
 from textblob import TextBlob
 

--- a/bot_tests.py
+++ b/bot_tests.py
@@ -13,6 +13,7 @@ os.environ.setdefault('MESSENGER_APP_SECRET', 'test-app-secret')
 
 import bot
 import nltk
+from nltk_guard import UnsafeNltkResourceError, validate_nltk_resource_name
 nltk.data.path.append(os.getcwd() + '/nltk_data')
 from textblob import TextBlob
 from webtest import TestApp
@@ -82,6 +83,27 @@ class BotTest(unittest.TestCase):
         response = "reviewed response"
 
         self.assertEqual(bot.safe_response(response), response)
+
+    def testNltkResourcePathGuardRejectsEncodedTraversal(self):
+        unsafe_resources = (
+            "nltk:%2fetc%2fpasswd",
+            "nltk:corpora/%2e%2e/%2e%2e/etc/passwd",
+            "nltk:corpora/..%2f..%2fetc%2fpasswd",
+            "nltk:%252fproc%252fself%252fenviron",
+            "nltk:C%3a%5cWindows%5cwin.ini",
+        )
+
+        for resource_name in unsafe_resources:
+            with self.subTest(resource_name=resource_name):
+                with self.assertRaises(UnsafeNltkResourceError):
+                    nltk.data.load(resource_name, format="raw")
+
+        with self.assertRaises(UnsafeNltkResourceError):
+            nltk.data.load(resource_url="nltk:%2fetc%2fpasswd", format="raw")
+
+    def testNltkResourcePathGuardAllowsFixedCorpusNames(self):
+        validate_nltk_resource_name("tokenizers/punkt/english.pickle")
+        validate_nltk_resource_name("taggers/averaged_perceptron_tagger_eng/")
 
 
 class TestBottleApp(unittest.TestCase):

--- a/docs/plans/2026-06-20-nltk-resource-path-guard.md
+++ b/docs/plans/2026-06-20-nltk-resource-path-guard.md
@@ -1,0 +1,38 @@
+---
+title: Guard NLTK resource paths
+status: completed
+date: 2026-06-20
+---
+
+# Guard NLTK Resource Paths
+
+## Problem
+
+NLTK 3.9.4 has no published patched release for GHSA-p4gq-832x-fm9v. Its
+resource loader checks traversal syntax before URL decoding, so encoded path
+separators can escape configured NLTK data roots when an attacker controls a
+resource identifier.
+
+Valleybot passes user messages to TextBlob, not to `nltk.data.load()`, but the
+dependency remains part of the public request path. The application needs a
+local defense that does not change normal fixed corpus lookup behavior.
+
+## Implementation
+
+- Wrap `nltk.data.load()` before importing TextBlob.
+- Repeatedly decode resource identifiers and reject POSIX absolute paths,
+  Windows drive-qualified paths, or `..` segments after normalizing path
+  separators.
+- Keep fixed tokenizer and tagger resource names valid.
+- Compile the guard during `make lint` and enforce its installation through the
+  dependency-free contract suite.
+- Add runtime regressions for encoded absolute paths, encoded traversal,
+  encoded separators, and repeated encoding.
+
+## Verification
+
+- Repository-root `make check` passed in a clean exact-head checkout.
+- External-directory `make check` passed through the absolute Makefile path.
+- The focused unittest suite rejected every hostile resource identifier and
+  preserved normal TextBlob behavior.
+- `git diff --check` and `git fsck --strict` passed.

--- a/nltk_guard.py
+++ b/nltk_guard.py
@@ -1,0 +1,59 @@
+"""Runtime guard for untrusted NLTK resource identifiers."""
+
+from functools import wraps
+from urllib.parse import unquote
+
+
+class UnsafeNltkResourceError(ValueError):
+    """Raised when an NLTK resource identifier escapes its data roots."""
+
+
+def _fully_unquote(value):
+    decoded = value
+    for _ in range(4):
+        next_value = unquote(decoded)
+        if next_value == decoded:
+            break
+        decoded = next_value
+    return decoded
+
+
+def validate_nltk_resource_name(resource_name):
+    """Reject absolute and parent-traversing NLTK resource paths."""
+    if not isinstance(resource_name, str):
+        return
+
+    decoded = _fully_unquote(resource_name)
+    if decoded.lower().startswith("nltk:"):
+        decoded = decoded[5:]
+
+    normalized = decoded.replace("\\", "/")
+    path_parts = normalized.split("/")
+    drive_absolute = (
+        len(normalized) >= 3
+        and normalized[1] == ":"
+        and normalized[2] == "/"
+    )
+    if (
+        normalized.startswith("/")
+        or drive_absolute
+        or any(part == ".." for part in path_parts)
+    ):
+        raise UnsafeNltkResourceError("Unsafe NLTK resource path rejected")
+
+
+def install_nltk_load_guard(nltk_module):
+    """Wrap nltk.data.load once so decoded paths are checked before loading."""
+    original_load = getattr(nltk_module.data, "load", None)
+    if original_load is None:
+        return
+    if getattr(original_load, "_valleybot_path_guard", False):
+        return
+
+    @wraps(original_load)
+    def guarded_load(resource_url, *args, **kwargs):
+        validate_nltk_resource_name(resource_url)
+        return original_load(resource_url, *args, **kwargs)
+
+    guarded_load._valleybot_path_guard = True
+    nltk_module.data.load = guarded_load

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -101,6 +101,9 @@ SLACK_REPLAY_PLAN_PATH = (
 WEB_CHAT_LENGTH_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-17-web-chat-input-length.md"
 )
+NLTK_RESOURCE_GUARD_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-20-nltk-resource-path-guard.md"
+)
 
 
 class FakeBottle:
@@ -371,6 +374,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(SLACK_SIGNING_SECRET_PLAN_PATH, "Slack signing secret")
     assert_completed_plan(SLACK_REPLAY_PLAN_PATH, "Slack request replay guard")
     assert_completed_plan(WEB_CHAT_LENGTH_PLAN_PATH, "web chat input length")
+    assert_completed_plan(NLTK_RESOURCE_GUARD_PLAN_PATH, "NLTK resource path guard")
     registered = registered_main_tests(
         (ROOT / "scripts" / "check_valleybot_contracts.py").read_text(encoding="utf-8")
     )
@@ -514,6 +518,45 @@ def test_runtime_and_ci_contracts():
         "Bottle/WebTest must cover Messenger verification mode",
     )
     assert_true("test_messenger_verification_escapes_reflected_markup" in Path(__file__).read_text(encoding="utf-8"), "dependency-free contracts must cover reflected challenge markup")
+
+
+def test_nltk_resource_path_guard_contracts():
+    bot_source = (ROOT / "bot.py").read_text(encoding="utf-8")
+    guard_source = (ROOT / "nltk_guard.py").read_text(encoding="utf-8")
+    tests_source = (ROOT / "bot_tests.py").read_text(encoding="utf-8")
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    for contract in (
+        "from nltk_guard import install_nltk_load_guard",
+        "install_nltk_load_guard(nltk)",
+    ):
+        assert_true(contract in bot_source, "missing NLTK guard installation {0}".format(contract))
+    for contract in (
+        "def validate_nltk_resource_name(resource_name):",
+        "decoded = _fully_unquote(resource_name)",
+        'normalized = decoded.replace("\\\\", "/")',
+        'normalized[1] == ":"',
+        'any(part == ".." for part in path_parts)',
+        "def install_nltk_load_guard(nltk_module):",
+        'original_load = getattr(nltk_module.data, "load", None)',
+        "validate_nltk_resource_name(resource_url)",
+    ):
+        assert_true(contract in guard_source, "missing NLTK path guard contract {0}".format(contract))
+    for contract in (
+        "testNltkResourcePathGuardRejectsEncodedTraversal",
+        "nltk:%2fetc%2fpasswd",
+        "nltk:%252fproc%252fself%252fenviron",
+        "nltk:C%3a%5cWindows%5cwin.ini",
+        'resource_url="nltk:%2fetc%2fpasswd"',
+        "testNltkResourcePathGuardAllowsFixedCorpusNames",
+    ):
+        assert_true(contract in tests_source, "missing NLTK path regression {0}".format(contract))
+    assert_true("nltk_guard.py" in makefile, "Make lint must compile the NLTK path guard")
+    assert_true(
+        "URL-encoded NLTK resource paths" in readme,
+        "README must document the NLTK resource path guard",
+    )
 
 
 def test_messenger_post_rejects_oversized_declared_body():
@@ -1807,6 +1850,7 @@ def main():
     tests = [
         test_completed_plans_are_in_docs_plans,
         test_runtime_and_ci_contracts,
+        test_nltk_resource_path_guard_contracts,
         test_messenger_post_rejects_oversized_declared_body,
         test_messenger_post_rejects_oversized_streamed_body,
         test_messenger_post_rejects_invalid_signature,


### PR DESCRIPTION
## Summary

Historical pull request metadata normalized for engineering-bar traceability. The original description is preserved verbatim below.

## Baseline

This pull request predates the current standardized engineering-bar description format.

## Improvements

- Preserves the original code, commits, review state, and pull request state.
- Adds structured documentation headings only; no repository files or merge decisions change.

## Validation

- Confirmed pull request #26 remains merged at head `d304771462de3c659fe3176ff4053c8f846c1268`.
- Confirmed this edit changes only the pull request description.

## Risk

No runtime or repository risk; this is metadata-only normalization.

## Follow-Ups

None required for this historical pull request.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because no repository or deployed runtime content changed.

## Original PR Description

## Summary

Valleybot now rejects URL-encoded absolute and parent-traversing NLTK resource identifiers before corpus loading, mitigating GHSA-p4gq-832x-fm9v while NLTK has no patched release.

## Why

NLTK 3.9.4 checks traversal syntax before URL decoding. Encoded separators can bypass that check and read local files if an attacker controls a resource identifier. Valleybot does not intentionally pass user text as a resource name, but NLTK is on the public request path and Dependabot flags the exact runtime version.

## Changes

- wrap `nltk.data.load()` before TextBlob imports it
- repeatedly decode and reject POSIX absolute, Windows drive-qualified, and parent-traversing paths
- preserve fixed tokenizer and tagger resource names and the `resource_url=` call shape
- enforce the mitigation with runtime and dependency-free static regressions
- document the unpatched dependency boundary and retention requirement

## Validation

- clean Python 3.12.8 virtual environment with `PYTHONPATH` removed
- repository-root `make check`: 70 contracts, 5 hostile web-chat mutations, and 41 unit tests
- external-directory `make -f .../Makefile check`: the same complete gate
- hostile `ROOT=/nonexistent` gate: passed
- `pip check`: no broken requirements
- `pip-audit -r requirements.txt --ignore-vuln GHSA-p4gq-832x-fm9v`: no other known vulnerabilities; private-index WebOb remains unauditable
- `git diff --check` and `git fsck --strict`: passed
- credential-shaped additions: 0

## Risk

This is a local mitigation for an unpatched upstream advisory. It wraps the loader at application startup; code that imports and invokes a separate NLTK loader before `bot.py` would not receive the guard. Live Slack and Messenger traffic was not exercised.

## Rollback

Revert `d304771`. That restores the prior NLTK behavior and reopens GHSA-p4gq-832x-fm9v exposure, so rollback should coincide with upgrading to a validated patched NLTK release or removing the dependency.

