### PR TITLE
ci: isolate Valleybot Make verification authority

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Install dependencies
         run: python -m pip install -r requirements.txt
       - name: Run repository checks
-        run: make check PYTHON=python
+        run: /usr/bin/make check PYTHON=python
       - name: Verify external working directory
-        run: cd "$(mktemp -d)" && make -C "$GITHUB_WORKSPACE" check PYTHON=python
+        run: cd "$(mktemp -d)" && /usr/bin/make -C "$GITHUB_WORKSPACE" check PYTHON=python
 
   codeql:
     name: CodeQL (${{ matrix.language }})

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 2026-06-21
+
+- Isolated Make verification authority from caller-controlled roots, shells,
+  startup files, Makefile lists, unsafe execution modes, and executable Make
+  syntax while preserving repository-contained bytecode cleanup.
+- Added a hostile-path authority harness and invoked hosted verification
+  through `/usr/bin/make`.
+
 - Guarded NLTK resource loading against URL-encoded absolute and parent-path
   traversal while preserving fixed TextBlob corpus names, with runtime and
   static regressions for GHSA-p4gq-832x-fm9v.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,53 @@
+.DEFAULT_GOAL := check
+.PHONY: __repository-make-authority build check clean lint prepare-corpora root-test test verify
+.SECONDEXPANSION:
+
 PYTHON ?= python3
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override PYTHON := $(value PYTHON)
+export PYTHON
+override REPOSITORY_MAKE_DOLLAR := $$
+override REPOSITORY_MAKE_OPEN := (
+ifneq ($(findstring $(REPOSITORY_MAKE_DOLLAR)$(REPOSITORY_MAKE_OPEN),$(value PYTHON)),)
+$(error PYTHON must be a literal executable path, not Make syntax)
+endif
+override SHELL := /bin/sh
+override .SHELLFLAGS := -c
+
+ifneq ($(filter command line,$(origin MAKEFLAGS)),)
+$(error MAKEFLAGS must not be overridden for repository verification)
+endif
+override REPOSITORY_MAKE_FIRST_FLAGS := $(firstword $(MAKEFLAGS))
+ifneq ($(filter -%,$(REPOSITORY_MAKE_FIRST_FLAGS)),)
+override REPOSITORY_MAKE_FIRST_FLAGS :=
+endif
+override REPOSITORY_MAKE_SHORT_FLAGS := $(REPOSITORY_MAKE_FIRST_FLAGS) $(filter-out --%,$(filter -%,$(MAKEFLAGS)))
+ifneq ($(findstring n,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring t,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring q,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring i,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(filter --just-print --dry-run --recon --touch --question --ignore-errors,$(MAKEFLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)
+endif
+override MAKEFILES :=
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(value MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+export ROOT
+ifeq ($(strip $(ROOT)),)
+$(error repository Makefile path could not be resolved)
+endif
 
 PYTHON_FILES := \
 	app.py \
@@ -14,26 +62,35 @@ PYTHON_FILES := \
 	scripts/check_valleybot_contracts.py \
 	scripts/test_web_chat_length_contract.py
 
-.PHONY: clean lint prepare-corpora test build verify check
+build check clean lint prepare-corpora root-test test verify: $$(if $$(filter file,$$(origin MAKEFILE_LIST)),,$$(error MAKEFILE_LIST must not be overridden))
+build check clean lint prepare-corpora root-test test verify: $$(if $$(shell path=$$$$(/usr/bin/printf '%s' '$$(subst ','"'"',$$(MAKEFILE_LIST))' | /usr/bin/sed 's/^ //') && [ -f "$$$$path" ] && /usr/bin/printf '%s' ok),,$$(error repository Makefile must be loaded alone))
+build check clean lint prepare-corpora root-test test verify: __repository-make-authority
 
-check: clean verify
-	$(MAKE) -C "$(ROOT)" clean
+__repository-make-authority::
+	@:
 
 clean:
-	find "$(ROOT)" -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
-	find "$(ROOT)" -type d -name '__pycache__' -prune -exec rm -rf {} +
+	/usr/bin/find "$$ROOT" -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
+	/usr/bin/find "$$ROOT" -type d -name '__pycache__' -prune -exec /bin/rm -rf {} +
 
 lint:
-	cd "$(ROOT)" && PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m py_compile $(PYTHON_FILES)
+	cd "$$ROOT" && PYTHONDONTWRITEBYTECODE=1 "$$PYTHON" -m py_compile $(PYTHON_FILES)
 
 prepare-corpora:
-	PYTHON=$(PYTHON) "$(ROOT)/scripts/prepare_nltk_data.sh"
+	PYTHON="$$PYTHON" "$$ROOT/scripts/prepare_nltk_data.sh"
 
 test: prepare-corpora
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(ROOT)/scripts/check_valleybot_contracts.py"
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) "$(ROOT)/scripts/test_web_chat_length_contract.py"
-	cd "$(ROOT)" && env SLACK_SIGNING_SECRET=test-slack-signing-secret MESSENGER_TOKEN=test-page-token MESSENGER_VERIFY_TOKEN=test-verify-token $(PYTHON) -m unittest bot_tests
+	PYTHONDONTWRITEBYTECODE=1 "$$PYTHON" "$$ROOT/scripts/check_valleybot_contracts.py"
+	PYTHONDONTWRITEBYTECODE=1 "$$PYTHON" "$$ROOT/scripts/test_web_chat_length_contract.py"
+	cd "$$ROOT" && /usr/bin/env SLACK_SIGNING_SECRET=test-slack-signing-secret MESSENGER_TOKEN=test-page-token MESSENGER_VERIFY_TOKEN=test-verify-token "$$PYTHON" -m unittest bot_tests
 
 build: lint
 
-verify: lint test build
+root-test:
+	/bin/sh "$$ROOT/scripts/test-makefile-root.sh"
+
+verify: root-test lint test build
+
+check: clean verify
+	/usr/bin/find "$$ROOT" -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
+	/usr/bin/find "$$ROOT" -type d -name '__pycache__' -prune -exec /bin/rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   The Makefile derives the repository root from its own location, so the same
   gate can run from an external working directory with
   `make -f /path/to/valleybot/Makefile check`.
+- `make root-test` exercises every public target across hostile external paths,
+  root and shell overrides, startup files, Makefile-list replacement, unsafe
+  execution modes, and literal Python executable paths.
+- Repository verification fixes its shell and root from the reviewed Makefile,
+  accepts only a literal `PYTHON` executable path, and rejects injected startup
+  files and non-executing or error-ignoring Make modes. Hosted checks invoke
+  the system `/usr/bin/make` explicitly.
 - `make prepare-corpora` installs the current TextBlob tokenizer and tagger
   data into the existing project-local `nltk_data` directory. Heroku runs the
   same step through `bin/post_compile`.
@@ -88,6 +95,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   `security-events: write` permission needed to upload results.
 - Completed maintenance plans live under `docs/plans` and are checked by
   `make check`.
+- See `docs/plans/2026-06-21-make-authority-isolation.md` for the Make
+  execution-authority and cleanup-containment boundary.
 - See `docs/plans/2026-06-13-messenger-message-replay-guard.md` for the bounded
   process-local Messenger retry guard.
 - See `docs/plans/2026-06-13-messenger-batch-processing-bound.md` for ordered,

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -1,0 +1,42 @@
+# Isolate Make Verification Authority
+
+## Status: Completed
+
+## Context
+
+The Makefile rooted cleanup and verification at its own location, but callers
+could still replace the recipe shell, load startup makefiles, override the
+Makefile list, select non-executing or error-ignoring modes, or embed Make
+syntax in the configurable Python executable value.
+
+## Requirements
+
+- Derive the repository root only from the reviewed Makefile path.
+- Fix recipes to `/bin/sh` and reject injected startup makefiles.
+- Reject replaced Makefile lists and dry-run, touch, question, or
+  ignore-errors modes for every public target.
+- Preserve caller selection of a literal Python executable, including paths
+  with spaces and shell metacharacters, without evaluating Make syntax.
+- Keep bytecode cleanup confined to the repository before and after the full
+  gate, including when invoked from an external directory.
+- Exercise all eight public targets under command-line and environment
+  root/shell attacks.
+- Invoke hosted root and external verification through `/usr/bin/make`.
+
+## Scope Boundaries
+
+- Do not change chatbot behavior, webhook authentication, replay handling,
+  moderation policy, dependency versions, or NLTK resource selection.
+- Do not remove the pinned corpus preparation step or real unittest suite.
+- Preserve exact test secrets as synthetic local fixtures only.
+
+## Verification
+
+- Repository and external-directory `make check` passed 70 dependency-free
+  contracts, five web-chat mutations, and 41 real unit tests.
+- The authority harness passed 40 public-target/root/shell cases, a literal
+  hostile Python path, two Make-syntax rejections, two Makefile-list
+  rejections, two startup boundaries, caller `MAKEFLAGS`, ten unsafe modes,
+  and repository cleanup containment.
+- Python and shell syntax, workflow YAML, `git diff --check`, intended-path,
+  artifact, and changed-line credential audits passed.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -104,6 +104,9 @@ WEB_CHAT_LENGTH_PLAN_PATH = (
 NLTK_RESOURCE_GUARD_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-20-nltk-resource-path-guard.md"
 )
+MAKE_AUTHORITY_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-21-make-authority-isolation.md"
+)
 
 
 class FakeBottle:
@@ -375,6 +378,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(SLACK_REPLAY_PLAN_PATH, "Slack request replay guard")
     assert_completed_plan(WEB_CHAT_LENGTH_PLAN_PATH, "web chat input length")
     assert_completed_plan(NLTK_RESOURCE_GUARD_PLAN_PATH, "NLTK resource path guard")
+    assert_completed_plan(MAKE_AUTHORITY_PLAN_PATH, "Make authority isolation")
     registered = registered_main_tests(
         (ROOT / "scripts" / "check_valleybot_contracts.py").read_text(encoding="utf-8")
     )
@@ -418,8 +422,8 @@ def test_runtime_and_ci_contracts():
             "github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e",
             "persist-credentials: false",
             "python -m pip install -r requirements.txt",
-            "make check PYTHON=python",
-            'make -C "$GITHUB_WORKSPACE" check PYTHON=python'):
+            "/usr/bin/make check PYTHON=python",
+            '/usr/bin/make -C "$GITHUB_WORKSPACE" check PYTHON=python'):
         assert_true(contract in workflow, "missing CI contract {0}".format(contract))
     assert_true("@v" not in workflow, "CI actions must use immutable commits")
     assert_true("ubuntu-latest" not in workflow, "CI must not use a floating Ubuntu runner")
@@ -490,16 +494,38 @@ def test_runtime_and_ci_contracts():
 
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
     makefile_lines = set(makefile.splitlines())
-    assert_true(
-        "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))"
-        in makefile_lines,
-        "Makefile must protect the loaded Makefile directory as the repository root",
-    )
+    for contract in (
+            ".DEFAULT_GOAL := check",
+            ".SECONDEXPANSION:",
+            "PYTHON ?= python3",
+            "override PYTHON := $(value PYTHON)",
+            "override SHELL := /bin/sh",
+            "override .SHELLFLAGS := -c",
+            "override MAKEFILES :=",
+            "ifneq ($(origin MAKEFILE_LIST),file)",
+            "export ROOT",
+            "root-test:",
+            '\t/bin/sh "$$ROOT/scripts/test-makefile-root.sh"'):
+        assert_true(contract in makefile_lines, "missing Make authority contract {0}".format(contract))
     assert_true("$(CURDIR)" not in makefile, "Makefile root must not trust the caller directory")
-    assert_true("PYTHON ?= python3" in makefile_lines, "Makefile must preserve the Python command override")
-    assert_true('find "$(ROOT)"' in makefile, "Makefile cleanup must stay inside the repository")
-    assert_true('"$(ROOT)/scripts/check_valleybot_contracts.py"' in makefile, "Makefile must use the rooted contract path")
-    assert_true('$(MAKE) -C "$(ROOT)" clean' in makefile, "recursive cleanup must select the repository directory")
+    assert_true("MAKEFLAGS must not be overridden" in makefile, "Makefile must reject caller MAKEFLAGS")
+    assert_true("MAKEFILES must be empty" in makefile, "Makefile must reject startup files")
+    assert_true("MAKEFILE_LIST must not be overridden" in makefile, "Makefile must reject Makefile-list replacement")
+    assert_true("PYTHON must be a literal executable path" in makefile, "Makefile must reject Python Make syntax")
+    assert_true('/usr/bin/find "$$ROOT"' in makefile, "Makefile cleanup must stay inside the repository")
+    assert_true('"$$ROOT/scripts/check_valleybot_contracts.py"' in makefile, "Makefile must use the rooted contract path")
+    assert_true("verify: root-test lint test build" in makefile_lines, "full verification must run authority tests")
+
+    authority_test = (ROOT / "scripts" / "test-makefile-root.sh").read_text(encoding="utf-8")
+    for contract in (
+            "40 target/authority cases",
+            "literal hostile Python path",
+            "MAKEFILE_LIST must not be overridden",
+            "MAKEFILES must be empty",
+            "MAKEFLAGS must not be overridden",
+            "cleanup containment",
+            "--ignore-errors"):
+        assert_true(contract in authority_test, "missing Make authority harness contract {0}".format(contract))
 
     app_source = (ROOT / "app.py").read_text(encoding="utf-8")
     runtime_tests = (ROOT / "bot_tests.py").read_text(encoding="utf-8")

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+set -eu
+PATH=/usr/bin:/bin
+export PATH
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
+TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/valleybot-make-authority-XXXXXX")
+trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
+unset MAKEFILES MAKEFILE_LIST MAKEFLAGS MFLAGS MAKEOVERRIDES ROOT SHELL
+CONTROL_DIR="$TEMP_ROOT/control"; CHECKOUT="$TEMP_ROOT/valleybot app's [gate] \"quoted\" \`touch VALLEYBOT_ROOT_MARKER\`"; ATTACKER_ROOT="$TEMP_ROOT/attacker"; LOG="$TEMP_ROOT/commands.log"; SHELL_LOG="$TEMP_ROOT/shell.log"
+mkdir -p "$CONTROL_DIR" "$CHECKOUT/scripts" "$ATTACKER_ROOT"; CONTROL_DIR=$(CDPATH= cd -- "$CONTROL_DIR" && /bin/pwd -P); CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && /bin/pwd -P); MAKEFILE="$CHECKOUT/Makefile"; cp "$ROOT_DIR/Makefile" "$MAKEFILE"
+FAKE_PYTHON="$TEMP_ROOT/trusted python's \"quoted\" \`touch VALLEYBOT_PYTHON_MARKER\` \$literal"; cat >"$FAKE_PYTHON" <<'EOF'
+#!/bin/sh
+printf '%s|%s|%s\n' "$PWD" "$0" "$*" >> "$VALLEYBOT_COMMAND_LOG"
+EOF
+chmod +x "$FAKE_PYTHON"
+for script in test-makefile-root.sh check_valleybot_contracts.py test_web_chat_length_contract.py prepare_nltk_data.sh; do cp "$FAKE_PYTHON" "$CHECKOUT/scripts/$script"; done
+for file in app.py bot.py bot_tests.py config.py nltk_guard.py settings.py slack_auth.py slack_replay.py slack.py; do : >"$CHECKOUT/$file"; done
+FAKE_SHELL="$TEMP_ROOT/fake-shell"; printf '#!/bin/sh\nprintf invoked >> %s\nexec /bin/sh "$@"\n' "'$SHELL_LOG'" >"$FAKE_SHELL"; chmod +x "$FAKE_SHELL"
+run_case() { target=$1; mode=$2; rm -f "$LOG" "$SHELL_LOG"; : >"$CHECKOUT/probe.pyc"; : >"$ATTACKER_ROOT/keep.pyc"; set +e; case "$mode" in default) (cd "$CONTROL_DIR"&&VALLEYBOT_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1;; command-root) (cd "$CONTROL_DIR"&&VALLEYBOT_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" ROOT="$ATTACKER_ROOT" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1;; environment-root) (cd "$CONTROL_DIR"&&ROOT="$ATTACKER_ROOT" VALLEYBOT_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1;; command-shell) (cd "$CONTROL_DIR"&&VALLEYBOT_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" SHELL="$FAKE_SHELL" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1;; environment-shell) (cd "$CONTROL_DIR"&&SHELL="$FAKE_SHELL" VALLEYBOT_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1;; esac; status=$?; set -e; [ "$status" -eq 0 ]; [ ! -e "$SHELL_LOG" ]; [ -e "$ATTACKER_ROOT/keep.pyc" ]; case "$target" in clean) [ ! -e "$CHECKOUT/probe.pyc" ];; *) grep -Fq "$CHECKOUT" "$LOG";; esac; }
+executed=0; for target in build check clean lint prepare-corpora root-test test verify; do for mode in default command-root environment-root command-shell environment-shell; do run_case "$target" "$mode"; executed=$((executed+1)); done; done; [ "$executed" -eq 40 ]
+rm -f "$LOG"; (cd "$CONTROL_DIR"&&VALLEYBOT_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" check) >/dev/null 2>&1; grep -Fq "$FAKE_PYTHON" "$LOG"; [ ! -e "$CONTROL_DIR/VALLEYBOT_ROOT_MARKER" ]; [ ! -e "$CONTROL_DIR/VALLEYBOT_PYTHON_MARKER" ]
+MARK="$TEMP_ROOT/python-syntax"; BAD="\$(shell /usr/bin/touch '$MARK')"; if (cd "$CONTROL_DIR"&&/usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$BAD" lint) >"$TEMP_ROOT/python.out" 2>&1; then exit 1; fi; [ ! -e "$MARK" ]
+ENV_MARK="$TEMP_ROOT/python-environment-syntax"; ENV_BAD="\$(shell /usr/bin/touch '$ENV_MARK')"; if (cd "$CONTROL_DIR"&&PYTHON="$ENV_BAD" /usr/bin/make --environment-overrides --no-print-directory -f "$MAKEFILE" lint) >"$TEMP_ROOT/python-environment.out" 2>&1; then exit 1; fi; [ ! -e "$ENV_MARK" ]
+if (cd "$CONTROL_DIR"&&/usr/bin/make --no-print-directory -f "$MAKEFILE" MAKEFILE_LIST=/tmp/untrusted check) >"$TEMP_ROOT/list" 2>&1; then exit 1; fi; grep -Fq 'MAKEFILE_LIST must not be overridden' "$TEMP_ROOT/list"
+if (cd "$CONTROL_DIR"&&MAKEFILE_LIST=/tmp/untrusted /usr/bin/make --environment-overrides --no-print-directory -f "$MAKEFILE" check) >"$TEMP_ROOT/list-environment" 2>&1; then exit 1; fi; grep -Fq 'MAKEFILE_LIST must not be overridden' "$TEMP_ROOT/list-environment"
+PRE="$TEMP_ROOT/pre.mk"; PRE_MARKER="$TEMP_ROOT/pre-ran"; printf '%s\n' "\$(shell /usr/bin/touch '$PRE_MARKER')" >"$PRE"; if (cd "$CONTROL_DIR"&&MAKEFILES="$PRE" /usr/bin/make --no-print-directory -f "$MAKEFILE" check) >"$TEMP_ROOT/pre" 2>&1; then exit 1; fi; grep -Fq 'MAKEFILES must be empty' "$TEMP_ROOT/pre"; [ -e "$PRE_MARKER" ]
+EARLY="$TEMP_ROOT/early.mk"; EARLY_MARKER="$TEMP_ROOT/early-ran"; printf '%s\n' "\$(shell /usr/bin/touch '$EARLY_MARKER')" >"$EARLY"; if (cd "$CONTROL_DIR"&&/usr/bin/make --no-print-directory -f "$EARLY" -f "$MAKEFILE" check) >"$TEMP_ROOT/early" 2>&1; then exit 1; fi; [ -s "$TEMP_ROOT/early" ]; [ -e "$EARLY_MARKER" ]
+if (cd "$CONTROL_DIR"&&/usr/bin/make --no-print-directory -f "$MAKEFILE" MAKEFLAGS=-n check) >"$TEMP_ROOT/flags" 2>&1; then exit 1; fi; grep -Fq 'MAKEFLAGS must not be overridden' "$TEMP_ROOT/flags"
+for flag in -n --just-print --dry-run --recon -t --touch -q --question -i --ignore-errors; do if (cd "$CONTROL_DIR"&&/usr/bin/make "$flag" --no-print-directory -f "$MAKEFILE" check) >"$TEMP_ROOT/flag" 2>&1; then exit 1; fi; grep -Fq 'non-executing or error-ignoring MAKEFLAGS are not supported' "$TEMP_ROOT/flag"; done
+printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python path, 2 raw Make-syntax rejections, 2 MAKEFILE_LIST rejections, 2 startup-boundary cases, cleanup containment, caller MAKEFLAGS rejection, and 10 mode rejections'


### PR DESCRIPTION
## Summary

Harden Valleybot's repository verification boundary so caller-controlled GNU Make state cannot redirect trusted cleanup and tests, without changing chatbot, webhook, replay, moderation, dependency, or NLTK behavior.

## Baseline

`master` at `a7fe53b7c261616a61e4750361e3d6327d4158a3` passed 70 dependency-free contracts, five web-chat mutation rejections, and 41 real tests after installing the pinned requirements. The Makefile protected only `ROOT`, leaving Python expressions, recipe shell state, startup files, Makefile-list replacement, and unsafe execution modes caller-controlled.

## Improvements

- Adds a 40-case authority harness across all eight public targets and five root/shell modes.
- Preserves repository-contained bytecode cleanup before and after the full gate.
- Rejects injected startup files, replaced Makefile lists, caller `MAKEFLAGS`, dry-run/touch/question/ignore-error modes, and Make syntax in `PYTHON`.
- Invokes both hosted root and external gates through `/usr/bin/make`.
- Records the authority and cleanup-containment boundary in maintained documentation.

## Validation

Validated exact commit `c39a2c6ba7edea271b186d7ecce55c989f6e3559`.

- Repository and external-directory `make check`: 70 dependency-free contracts, 5 web-chat mutations, and 41 unit tests passed per invocation.
- Authority harness: 40 target/root/shell cases, literal hostile Python path, 2 Make-syntax rejections, 2 Makefile-list rejections, 2 startup boundaries, cleanup containment, caller `MAKEFLAGS`, and 10 unsafe modes passed.
- Eight focused hostile mutations were rejected.
- Shell syntax, workflow YAML, `git diff --check`, `git fsck --strict`, intended-path, artifact, and changed-line credential audits passed.

## Risk

- The Makefile intentionally rejects caller startup files, executable Make syntax in `PYTHON`, and non-executing or error-ignoring modes.
- Corpus preparation still depends on the pinned Python packages and may access NLTK download sources when project-local resources are missing.
- Process-local replay guards and moderation review boundaries are unchanged.

## Follow-Ups

- Monitor the hosted Python 3.10, 3.12, and 3.14 matrix after the authority gate is introduced.
- Keep pinned NLTK resources and dependency versions coordinated with future security advisories.