### PR TITLE
Clarify Valleybot Make authority boundary

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Install dependencies
         run: python -m pip install -r requirements.txt
       - name: Run repository checks
-        run: /usr/bin/make check PYTHON=python
+        run: /usr/bin/make check PYTHON="$(command -v python)"
       - name: Verify external working directory
-        run: cd "$(mktemp -d)" && /usr/bin/make -C "$GITHUB_WORKSPACE" check PYTHON=python
+        run: cd "$(mktemp -d)" && /usr/bin/make -C "$GITHUB_WORKSPACE" check PYTHON="$(command -v python)"
 
   codeql:
     name: CodeQL (${{ matrix.language }})

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
   syntax while preserving repository-contained bytecode cleanup.
 - Added a hostile-path authority harness and invoked hosted verification
   through `/usr/bin/make`.
+- Baked an absolute Python interpreter into verification recipes, rejected
+  PATH-shadowed defaults and later shell false-success, and isolated startup
+  from `PYTHONPATH`, user-site packages, and `sitecustomize.py`.
 
 - Guarded NLTK resource loading against URL-encoded absolute and parent-path
   traversal while preserving fixed TextBlob corpus names, with runtime and

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,18 @@
 .PHONY: __repository-make-authority build check clean lint prepare-corpora root-test test verify
 .SECONDEXPANSION:
 
-PYTHON ?= python3
+ifeq ($(origin PYTHON),undefined)
+override PYTHON := /usr/bin/python3
+else
 override PYTHON := $(value PYTHON)
+endif
 export PYTHON
 override REPOSITORY_MAKE_DOLLAR := $$
 override REPOSITORY_MAKE_OPEN := (
 ifneq ($(findstring $(REPOSITORY_MAKE_DOLLAR)$(REPOSITORY_MAKE_OPEN),$(value PYTHON)),)
+$(error PYTHON must be a literal executable path, not Make syntax)
+endif
+ifneq ($(findstring $(REPOSITORY_MAKE_DOLLAR){,$(value PYTHON)),)
 $(error PYTHON must be a literal executable path, not Make syntax)
 endif
 override SHELL := /bin/sh
@@ -43,10 +49,19 @@ override MAKEFILES :=
 ifneq ($(origin MAKEFILE_LIST),file)
 $(error MAKEFILE_LIST must not be overridden)
 endif
+override REPOSITORY_MAKEFILE_LIST := $(value MAKEFILE_LIST)
 override ROOT := $(shell path='$(subst ','"'"',$(value MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
 export ROOT
 ifeq ($(strip $(ROOT)),)
 $(error repository Makefile path could not be resolved)
+endif
+override REPOSITORY_SHELL_LITERAL = $(subst $$,$$$$,$(subst ','"'"',$1))
+override REPOSITORY_PARSE_SHELL_LITERAL = $(subst ','"'"',$1)
+override REPOSITORY_ROOT_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(ROOT))
+override REPOSITORY_PYTHON_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(PYTHON))
+override REPOSITORY_PYTHON_IS_VALID := $(shell candidate='$(call REPOSITORY_PARSE_SHELL_LITERAL,$(PYTHON))'; /bin/expr "$$candidate" : '^/' >/dev/null && [ -x "$$candidate" ] && /usr/bin/printf '%s' yes)
+ifneq ($(REPOSITORY_PYTHON_IS_VALID),yes)
+$(error PYTHON must be an absolute executable path)
 endif
 
 PYTHON_FILES := \
@@ -62,35 +77,39 @@ PYTHON_FILES := \
 	scripts/check_valleybot_contracts.py \
 	scripts/test_web_chat_length_contract.py
 
-build check clean lint prepare-corpora root-test test verify: $$(if $$(filter file,$$(origin MAKEFILE_LIST)),,$$(error MAKEFILE_LIST must not be overridden))
-build check clean lint prepare-corpora root-test test verify: $$(if $$(shell path=$$$$(/usr/bin/printf '%s' '$$(subst ','"'"',$$(MAKEFILE_LIST))' | /usr/bin/sed 's/^ //') && [ -f "$$$$path" ] && /usr/bin/printf '%s' ok),,$$(error repository Makefile must be loaded alone))
-build check clean lint prepare-corpora root-test test verify: __repository-make-authority
+build check clean lint prepare-corpora root-test test verify:: $$(if $$(filter file,$$(origin MAKEFILE_LIST)),,$$(error MAKEFILE_LIST must not be overridden))
+build check clean lint prepare-corpora root-test test verify:: $$(if $$(filter-out $$(REPOSITORY_MAKEFILE_LIST),$$(value MAKEFILE_LIST)),$$(error repository Makefile must be loaded alone))
+build check clean lint prepare-corpora root-test test verify:: $$(if $$(filter-out $$(value MAKEFILE_LIST),$$(REPOSITORY_MAKEFILE_LIST)),$$(error repository Makefile must be loaded alone))
+build check clean lint prepare-corpora root-test test verify:: __repository-make-authority
 
 __repository-make-authority::
 	@:
 
-clean:
-	/usr/bin/find "$$ROOT" -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
-	/usr/bin/find "$$ROOT" -type d -name '__pycache__' -prune -exec /bin/rm -rf {} +
+define REPOSITORY_PUBLIC_RECIPES
+clean::
+	/usr/bin/find '$(REPOSITORY_ROOT_LITERAL)' -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
+	/usr/bin/find '$(REPOSITORY_ROOT_LITERAL)' -type d -name '__pycache__' -prune -exec /bin/rm -rf {} +
 
-lint:
-	cd "$$ROOT" && PYTHONDONTWRITEBYTECODE=1 "$$PYTHON" -m py_compile $(PYTHON_FILES)
+lint::
+	cd '$(REPOSITORY_ROOT_LITERAL)' && PYTHONDONTWRITEBYTECODE=1 '$(REPOSITORY_PYTHON_LITERAL)' -I -B -m py_compile $(PYTHON_FILES)
 
-prepare-corpora:
-	PYTHON="$$PYTHON" "$$ROOT/scripts/prepare_nltk_data.sh"
+prepare-corpora::
+	REPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/run-python.sh' --module textblob.download_corpora lite
 
-test: prepare-corpora
-	PYTHONDONTWRITEBYTECODE=1 "$$PYTHON" "$$ROOT/scripts/check_valleybot_contracts.py"
-	PYTHONDONTWRITEBYTECODE=1 "$$PYTHON" "$$ROOT/scripts/test_web_chat_length_contract.py"
-	cd "$$ROOT" && /usr/bin/env SLACK_SIGNING_SECRET=test-slack-signing-secret MESSENGER_TOKEN=test-page-token MESSENGER_VERIFY_TOKEN=test-verify-token "$$PYTHON" -m unittest bot_tests
+test:: prepare-corpora
+	REPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/run-python.sh' '$(REPOSITORY_ROOT_LITERAL)/scripts/check_valleybot_contracts.py'
+	REPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/run-python.sh' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_web_chat_length_contract.py'
+	cd '$(REPOSITORY_ROOT_LITERAL)' && /usr/bin/env SLACK_SIGNING_SECRET=test-slack-signing-secret MESSENGER_TOKEN=test-page-token MESSENGER_VERIFY_TOKEN=test-verify-token REPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/run-python.sh' '$(REPOSITORY_ROOT_LITERAL)/bot_tests.py'
 
-build: lint
+build:: lint
 
-root-test:
-	/bin/sh "$$ROOT/scripts/test-makefile-root.sh"
+root-test::
+	/bin/sh '$(REPOSITORY_ROOT_LITERAL)/scripts/test-makefile-root.sh'
 
-verify: root-test lint test build
+verify:: root-test lint test build
 
-check: clean verify
-	/usr/bin/find "$$ROOT" -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
-	/usr/bin/find "$$ROOT" -type d -name '__pycache__' -prune -exec /bin/rm -rf {} +
+check:: clean verify
+	/usr/bin/find '$(REPOSITORY_ROOT_LITERAL)' -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
+	/usr/bin/find '$(REPOSITORY_ROOT_LITERAL)' -type d -name '__pycache__' -prune -exec /bin/rm -rf {} +
+endef
+$(eval $(REPOSITORY_PUBLIC_RECIPES))

--- a/README.md
+++ b/README.md
@@ -77,11 +77,16 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   `make -f /path/to/valleybot/Makefile check`.
 - `make root-test` exercises every public target across hostile external paths,
   root and shell overrides, startup files, Makefile-list replacement, unsafe
-  execution modes, and literal Python executable paths.
-- Repository verification fixes its shell and root from the reviewed Makefile,
-  accepts only a literal `PYTHON` executable path, and rejects injected startup
-  files and non-executing or error-ignoring Make modes. Hosted checks invoke
-  the system `/usr/bin/make` explicitly.
+  execution modes, literal Python executable paths, and caller-owned Make
+  program controls.
+- Repository verification fixes its shell and root from the reviewed Makefile
+  when it is loaded without caller-supplied Make programs. Caller-supplied Make
+  programs are outside this trust boundary. That includes `MAKEFILES` startup
+  files, extra `-f` makefiles, global or target-specific `override`
+  directives, replacement or double-colon recipes, and caller-selected
+  `SHELL`, `.SHELLFLAGS`, `PATH`, or tool variables. The harness records that
+  those inputs are caller authority; hosted checks invoke the system
+  `/usr/bin/make` explicitly without additional Make programs.
 - `make prepare-corpora` installs the current TextBlob tokenizer and tagger
   data into the existing project-local `nltk_data` directory. Heroku runs the
   same step through `bin/post_compile`.

--- a/README.md
+++ b/README.md
@@ -84,9 +84,11 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   programs are outside this trust boundary. That includes `MAKEFILES` startup
   files, extra `-f` makefiles, global or target-specific `override`
   directives, replacement or double-colon recipes, and caller-selected
-  `SHELL`, `.SHELLFLAGS`, `PATH`, or tool variables. The harness records that
-  those inputs are caller authority; hosted checks invoke the system
-  `/usr/bin/make` explicitly without additional Make programs.
+  `SHELL`, `.SHELLFLAGS`, `PATH`, or tool variables. Without additional Make
+  programs, recipes bake the reviewed root and absolute Python executable,
+  reject PATH-shadowed defaults, and use isolated Python startup (`-I -B`) to
+  ignore `PYTHONPATH`, user-site packages, and `sitecustomize.py`. Hosted checks
+  invoke `/usr/bin/make` explicitly without additional Make programs.
 - `make prepare-corpora` installs the current TextBlob tokenizer and tagger
   data into the existing project-local `nltk_data` directory. Heroku runs the
   same step through `bin/post_compile`.

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -2,4 +2,6 @@
 set -euo pipefail
 
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-PYTHON=python "$ROOT_DIR/scripts/prepare_nltk_data.sh"
+REPOSITORY_PYTHON=$(command -v python)
+export REPOSITORY_PYTHON
+"$ROOT_DIR/scripts/prepare_nltk_data.sh"

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -27,6 +27,8 @@ replacement or double-colon recipes, and caller-selected `SHELL`,
   rather than as authenticated repository verification.
 - Preserve caller selection of a literal Python executable, including paths
   with spaces and shell metacharacters, without evaluating Make syntax.
+- Require absolute Python executables, bake the reviewed selection into recipes,
+  and enforce isolated startup with `-I -B`.
 - Keep bytecode cleanup confined to the repository before and after the full
   gate, including when invoked from an external directory.
 - Exercise all eight public targets under command-line and environment
@@ -50,7 +52,7 @@ replacement or double-colon recipes, and caller-selected `SHELL`,
 - The authority harness passed 40 public-target/root/shell cases, a literal
   hostile Python path, two Make-syntax rejections, two Makefile-list
   rejections, two startup boundaries, caller `MAKEFLAGS`, ten unsafe modes,
-  repository cleanup containment, and a global-override shell boundary control
-  showing that caller Make programs can make a failing tool look successful.
+  repository cleanup containment, global-override shell rejection, PATH-Python
+  rejection, and a hostile `sitecustomize.py` isolation proof.
 - Python and shell syntax, workflow YAML, `git diff --check`, intended-path,
   artifact, and changed-line credential audits passed.

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -9,12 +9,22 @@ could still replace the recipe shell, load startup makefiles, override the
 Makefile list, select non-executing or error-ignoring modes, or embed Make
 syntax in the configurable Python executable value.
 
+This plan covers repository-controlled Make invocations. Caller-supplied Make
+programs are outside this trust boundary. That includes `MAKEFILES` startup
+files, extra `-f` makefiles, global or target-specific `override` directives,
+replacement or double-colon recipes, and caller-selected `SHELL`,
+`.SHELLFLAGS`, `PATH`, or tool variables.
+
 ## Requirements
 
 - Derive the repository root only from the reviewed Makefile path.
-- Fix recipes to `/bin/sh` and reject injected startup makefiles.
+- Fix recipes to `/bin/sh` for repository-controlled invocations.
 - Reject replaced Makefile lists and dry-run, touch, question, or
-  ignore-errors modes for every public target.
+  ignore-errors modes for every public target when no caller-supplied Make
+  programs are loaded.
+- Treat startup files, extra makefiles, override directives, replacement
+  recipes, double-colon recipes, and caller-selected tools as caller authority
+  rather than as authenticated repository verification.
 - Preserve caller selection of a literal Python executable, including paths
   with spaces and shell metacharacters, without evaluating Make syntax.
 - Keep bytecode cleanup confined to the repository before and after the full
@@ -29,6 +39,9 @@ syntax in the configurable Python executable value.
   moderation policy, dependency versions, or NLTK resource selection.
 - Do not remove the pinned corpus preparation step or real unittest suite.
 - Preserve exact test secrets as synthetic local fixtures only.
+- Do not claim GNU Make can prevent parse-time execution of caller-supplied
+  startup or extra makefiles. They are rejected or characterized only after GNU
+  Make has already accepted them as caller programs.
 
 ## Verification
 
@@ -37,6 +50,7 @@ syntax in the configurable Python executable value.
 - The authority harness passed 40 public-target/root/shell cases, a literal
   hostile Python path, two Make-syntax rejections, two Makefile-list
   rejections, two startup boundaries, caller `MAKEFLAGS`, ten unsafe modes,
-  and repository cleanup containment.
+  repository cleanup containment, and a global-override shell boundary control
+  showing that caller Make programs can make a failing tool look successful.
 - Python and shell syntax, workflow YAML, `git diff --check`, intended-path,
   artifact, and changed-line credential audits passed.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -422,8 +422,8 @@ def test_runtime_and_ci_contracts():
             "github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e",
             "persist-credentials: false",
             "python -m pip install -r requirements.txt",
-            "/usr/bin/make check PYTHON=python",
-            '/usr/bin/make -C "$GITHUB_WORKSPACE" check PYTHON=python'):
+            '/usr/bin/make check PYTHON="$(command -v python)"',
+            '/usr/bin/make -C "$GITHUB_WORKSPACE" check PYTHON="$(command -v python)"'):
         assert_true(contract in workflow, "missing CI contract {0}".format(contract))
     assert_true("@v" not in workflow, "CI actions must use immutable commits")
     assert_true("ubuntu-latest" not in workflow, "CI must not use a floating Ubuntu runner")
@@ -497,24 +497,25 @@ def test_runtime_and_ci_contracts():
     for contract in (
             ".DEFAULT_GOAL := check",
             ".SECONDEXPANSION:",
-            "PYTHON ?= python3",
+            "override PYTHON := /usr/bin/python3",
             "override PYTHON := $(value PYTHON)",
             "override SHELL := /bin/sh",
             "override .SHELLFLAGS := -c",
             "override MAKEFILES :=",
             "ifneq ($(origin MAKEFILE_LIST),file)",
             "export ROOT",
-            "root-test:",
-            '\t/bin/sh "$$ROOT/scripts/test-makefile-root.sh"'):
+            "root-test::",
+            "\t/bin/sh '$(REPOSITORY_ROOT_LITERAL)/scripts/test-makefile-root.sh'"):
         assert_true(contract in makefile_lines, "missing Make authority contract {0}".format(contract))
     assert_true("$(CURDIR)" not in makefile, "Makefile root must not trust the caller directory")
     assert_true("MAKEFLAGS must not be overridden" in makefile, "Makefile must reject caller MAKEFLAGS")
     assert_true("MAKEFILES must be empty" in makefile, "Makefile must reject startup files")
     assert_true("MAKEFILE_LIST must not be overridden" in makefile, "Makefile must reject Makefile-list replacement")
     assert_true("PYTHON must be a literal executable path" in makefile, "Makefile must reject Python Make syntax")
-    assert_true('/usr/bin/find "$$ROOT"' in makefile, "Makefile cleanup must stay inside the repository")
-    assert_true('"$$ROOT/scripts/check_valleybot_contracts.py"' in makefile, "Makefile must use the rooted contract path")
-    assert_true("verify: root-test lint test build" in makefile_lines, "full verification must run authority tests")
+    assert_true("override REPOSITORY_ROOT_LITERAL :=" in makefile, "Makefile must embed its reviewed repository root")
+    assert_true("scripts/run-python.sh" in makefile, "Makefile must use the isolated Python launcher")
+    assert_true("verify:: root-test lint test build" in makefile_lines, "full verification must run authority tests")
+    assert_true("-I -B" in (ROOT / "scripts" / "run-python.sh").read_text(encoding="utf-8"), "Python launcher must isolate startup state")
 
     authority_test = (ROOT / "scripts" / "test-makefile-root.sh").read_text(encoding="utf-8")
     for contract in (
@@ -567,8 +568,9 @@ def test_make_authority_boundary_is_truthful():
 
     for contract in (
         "MAKE_BIN=${MAKE_BIN:-/usr/bin/make}",
-        "global override shell boundary control",
-        "caller global override SHELL can make a failing Python tool look successful",
+        "global override shell rejection",
+        "PATH-Python rejection",
+        "isolated Python startup",
     ):
         assert_true(contract in authority_test, "Make authority harness must include {0}".format(contract))
 

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -546,6 +546,33 @@ def test_runtime_and_ci_contracts():
     assert_true("test_messenger_verification_escapes_reflected_markup" in Path(__file__).read_text(encoding="utf-8"), "dependency-free contracts must cover reflected challenge markup")
 
 
+def test_make_authority_boundary_is_truthful():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    plan = MAKE_AUTHORITY_PLAN_PATH.read_text(encoding="utf-8")
+    authority_test = (ROOT / "scripts" / "test-makefile-root.sh").read_text(encoding="utf-8")
+
+    for document_name, document in (
+        ("README.md", " ".join(readme.split())),
+        ("Make authority plan", " ".join(plan.split())),
+    ):
+        for contract in (
+            "Caller-supplied Make programs are outside this trust boundary.",
+            "`MAKEFILES` startup files",
+            "extra `-f` makefiles",
+            "global or target-specific `override` directives",
+            "replacement or double-colon recipes",
+            "caller-selected `SHELL`, `.SHELLFLAGS`, `PATH`, or tool variables",
+        ):
+            assert_true(contract in document, "{0} must document {1}".format(document_name, contract))
+
+    for contract in (
+        "MAKE_BIN=${MAKE_BIN:-/usr/bin/make}",
+        "global override shell boundary control",
+        "caller global override SHELL can make a failing Python tool look successful",
+    ):
+        assert_true(contract in authority_test, "Make authority harness must include {0}".format(contract))
+
+
 def test_nltk_resource_path_guard_contracts():
     bot_source = (ROOT / "bot.py").read_text(encoding="utf-8")
     guard_source = (ROOT / "nltk_guard.py").read_text(encoding="utf-8")
@@ -1876,6 +1903,7 @@ def main():
     tests = [
         test_completed_plans_are_in_docs_plans,
         test_runtime_and_ci_contracts,
+        test_make_authority_boundary_is_truthful,
         test_nltk_resource_path_guard_contracts,
         test_messenger_post_rejects_oversized_declared_body,
         test_messenger_post_rejects_oversized_streamed_body,

--- a/scripts/prepare_nltk_data.sh
+++ b/scripts/prepare_nltk_data.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 export NLTK_DATA="$ROOT_DIR/nltk_data"
 
-python_bin=${PYTHON:-python3}
-"$python_bin" -m textblob.download_corpora lite
+: "${REPOSITORY_PYTHON:?REPOSITORY_PYTHON must name the reviewed absolute interpreter}"
+"$ROOT_DIR/scripts/run-python.sh" --module textblob.download_corpora lite

--- a/scripts/run-python.sh
+++ b/scripts/run-python.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+: "${REPOSITORY_PYTHON:?REPOSITORY_PYTHON must name the reviewed absolute interpreter}"
+
+case $REPOSITORY_PYTHON in
+    /*) ;;
+    *) printf '%s\n' 'REPOSITORY_PYTHON must be an absolute path' >&2; exit 2 ;;
+esac
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
+
+if [ "${1-}" = --module ]; then
+    shift
+    module=$1
+    shift
+    exec "$REPOSITORY_PYTHON" -I -B -c '
+import runpy
+import sys
+
+root = sys.argv[1]
+module = sys.argv[2]
+sys.argv = sys.argv[2:]
+sys.path.insert(0, root)
+runpy.run_module(module, run_name="__main__", alter_sys=True)
+' "$root" "$module" "$@"
+fi
+
+script=$1
+shift
+
+exec "$REPOSITORY_PYTHON" -I -B -c '
+import os
+import runpy
+import sys
+
+root = sys.argv[1]
+script = os.path.realpath(sys.argv[2])
+sys.argv = sys.argv[2:]
+sys.path.insert(0, root)
+sys.path.insert(0, os.path.dirname(script))
+runpy.run_path(script, run_name="__main__")
+' "$root" "$script" "$@"

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -37,6 +37,8 @@ chmod +x "$FAKE_PYTHON"
 for script in test-makefile-root.sh check_valleybot_contracts.py test_web_chat_length_contract.py prepare_nltk_data.sh; do
     cp "$FAKE_PYTHON" "$CHECKOUT/scripts/$script"
 done
+cp "$ROOT_DIR/scripts/run-python.sh" "$CHECKOUT/scripts/run-python.sh"
+chmod +x "$CHECKOUT/scripts/run-python.sh"
 for file in app.py bot.py bot_tests.py config.py nltk_guard.py settings.py slack_auth.py slack_replay.py slack.py; do
     : >"$CHECKOUT/$file"
 done
@@ -156,11 +158,26 @@ exit 0
 EOF
 chmod +x "$GLOBAL_SHELL"
 printf 'override SHELL := %s\noverride .SHELLFLAGS := -c\n' "$GLOBAL_SHELL" >"$GLOBAL_OVERRIDE"
-if ! (cd "$CONTROL_DIR" && VALLEYBOT_GLOBAL_OVERRIDE_LOG="$GLOBAL_SHELL_LOG" make_run -f "$MAKEFILE" -f "$GLOBAL_OVERRIDE" PYTHON=/bin/false lint) >"$TEMP_ROOT/global-override" 2>&1; then
+if (cd "$CONTROL_DIR" && VALLEYBOT_GLOBAL_OVERRIDE_LOG="$GLOBAL_SHELL_LOG" make_run -f "$MAKEFILE" -f "$GLOBAL_OVERRIDE" PYTHON=/usr/bin/false lint) >"$TEMP_ROOT/global-override" 2>&1; then
     exit 1
 fi
-[ -s "$GLOBAL_SHELL_LOG" ]
-grep -Fq 'py_compile' "$GLOBAL_SHELL_LOG"
+grep -Fq 'repository Makefile must be loaded alone' "$TEMP_ROOT/global-override"
+[ ! -e "$GLOBAL_SHELL_LOG" ]
+
+PATH_PYTHON="$TEMP_ROOT/python3"
+PATH_PYTHON_LOG="$TEMP_ROOT/path-python.log"
+cp "$FAKE_PYTHON" "$PATH_PYTHON"
+if (cd "$CONTROL_DIR" && PATH="$TEMP_ROOT:/usr/bin:/bin" VALLEYBOT_COMMAND_LOG="$PATH_PYTHON_LOG" make_run -f "$MAKEFILE" lint) >"$TEMP_ROOT/path-python" 2>&1; then
+    exit 1
+fi
+[ ! -e "$PATH_PYTHON_LOG" ]
+
+SITE_DIR="$TEMP_ROOT/site"
+SITE_MARKER="$TEMP_ROOT/sitecustomize-ran"
+mkdir -p "$SITE_DIR"
+printf '%s\n' "import os; open('$SITE_MARKER', 'w').close(); os._exit(0)" >"$SITE_DIR/sitecustomize.py"
+(cd "$ROOT_DIR" && PYTHONPATH="$SITE_DIR" make_run lint PYTHON=/usr/bin/python3) >"$TEMP_ROOT/sitecustomize" 2>&1
+[ ! -e "$SITE_MARKER" ]
 
 if (cd "$CONTROL_DIR" && make_run -f "$MAKEFILE" MAKEFLAGS=-n check) >"$TEMP_ROOT/flags" 2>&1; then
     exit 1
@@ -174,4 +191,4 @@ for flag in -n --just-print --dry-run --recon -t --touch -q --question -i --igno
     grep -Fq 'non-executing or error-ignoring MAKEFLAGS are not supported' "$TEMP_ROOT/flag"
 done
 
-printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python path, 2 raw Make-syntax rejections, 2 MAKEFILE_LIST rejections, 2 startup-boundary cases, cleanup containment, caller MAKEFLAGS rejection, global override shell boundary control showing caller global override SHELL can make a failing Python tool look successful, and 10 unsafe mode rejections'
+printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python path, 2 raw Make-syntax rejections, 2 MAKEFILE_LIST rejections, 2 startup-boundary cases, cleanup containment, global override shell rejection, PATH-Python rejection, isolated Python startup, caller MAKEFLAGS rejection, and 10 unsafe mode rejections'

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -1,30 +1,177 @@
 #!/usr/bin/env sh
 set -eu
+
 PATH=/usr/bin:/bin
 export PATH
-ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
+MAKE_BIN=${MAKE_BIN:-/usr/bin/make}
+
+if [ ! -x "$MAKE_BIN" ]; then
+    echo "MAKE_BIN must name an executable make: $MAKE_BIN" >&2
+    exit 1
+fi
+
+ROOT_DIR=$(CDPATH=; cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
 TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/valleybot-make-authority-XXXXXX")
 trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
 unset MAKEFILES MAKEFILE_LIST MAKEFLAGS MFLAGS MAKEOVERRIDES ROOT SHELL
-CONTROL_DIR="$TEMP_ROOT/control"; CHECKOUT="$TEMP_ROOT/valleybot app's [gate] \"quoted\" \`touch VALLEYBOT_ROOT_MARKER\`"; ATTACKER_ROOT="$TEMP_ROOT/attacker"; LOG="$TEMP_ROOT/commands.log"; SHELL_LOG="$TEMP_ROOT/shell.log"
-mkdir -p "$CONTROL_DIR" "$CHECKOUT/scripts" "$ATTACKER_ROOT"; CONTROL_DIR=$(CDPATH= cd -- "$CONTROL_DIR" && /bin/pwd -P); CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && /bin/pwd -P); MAKEFILE="$CHECKOUT/Makefile"; cp "$ROOT_DIR/Makefile" "$MAKEFILE"
-FAKE_PYTHON="$TEMP_ROOT/trusted python's \"quoted\" \`touch VALLEYBOT_PYTHON_MARKER\` \$literal"; cat >"$FAKE_PYTHON" <<'EOF'
+
+CONTROL_DIR="$TEMP_ROOT/control"
+CHECKOUT="$TEMP_ROOT/valleybot app's [gate] \"quoted\" \`touch VALLEYBOT_ROOT_MARKER\`"
+ATTACKER_ROOT="$TEMP_ROOT/attacker"
+LOG="$TEMP_ROOT/commands.log"
+SHELL_LOG="$TEMP_ROOT/shell.log"
+
+mkdir -p "$CONTROL_DIR" "$CHECKOUT/scripts" "$ATTACKER_ROOT"
+CONTROL_DIR=$(CDPATH=; cd -- "$CONTROL_DIR" && /bin/pwd -P)
+CHECKOUT=$(CDPATH=; cd -- "$CHECKOUT" && /bin/pwd -P)
+MAKEFILE="$CHECKOUT/Makefile"
+cp "$ROOT_DIR/Makefile" "$MAKEFILE"
+
+FAKE_PYTHON="$TEMP_ROOT/trusted python's \"quoted\" \`touch VALLEYBOT_PYTHON_MARKER\` \$literal"
+cat >"$FAKE_PYTHON" <<'EOF'
 #!/bin/sh
 printf '%s|%s|%s\n' "$PWD" "$0" "$*" >> "$VALLEYBOT_COMMAND_LOG"
 EOF
 chmod +x "$FAKE_PYTHON"
-for script in test-makefile-root.sh check_valleybot_contracts.py test_web_chat_length_contract.py prepare_nltk_data.sh; do cp "$FAKE_PYTHON" "$CHECKOUT/scripts/$script"; done
-for file in app.py bot.py bot_tests.py config.py nltk_guard.py settings.py slack_auth.py slack_replay.py slack.py; do : >"$CHECKOUT/$file"; done
-FAKE_SHELL="$TEMP_ROOT/fake-shell"; printf '#!/bin/sh\nprintf invoked >> %s\nexec /bin/sh "$@"\n' "'$SHELL_LOG'" >"$FAKE_SHELL"; chmod +x "$FAKE_SHELL"
-run_case() { target=$1; mode=$2; rm -f "$LOG" "$SHELL_LOG"; : >"$CHECKOUT/probe.pyc"; : >"$ATTACKER_ROOT/keep.pyc"; set +e; case "$mode" in default) (cd "$CONTROL_DIR"&&VALLEYBOT_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1;; command-root) (cd "$CONTROL_DIR"&&VALLEYBOT_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" ROOT="$ATTACKER_ROOT" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1;; environment-root) (cd "$CONTROL_DIR"&&ROOT="$ATTACKER_ROOT" VALLEYBOT_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1;; command-shell) (cd "$CONTROL_DIR"&&VALLEYBOT_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" SHELL="$FAKE_SHELL" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1;; environment-shell) (cd "$CONTROL_DIR"&&SHELL="$FAKE_SHELL" VALLEYBOT_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1;; esac; status=$?; set -e; [ "$status" -eq 0 ]; [ ! -e "$SHELL_LOG" ]; [ -e "$ATTACKER_ROOT/keep.pyc" ]; case "$target" in clean) [ ! -e "$CHECKOUT/probe.pyc" ];; *) grep -Fq "$CHECKOUT" "$LOG";; esac; }
-executed=0; for target in build check clean lint prepare-corpora root-test test verify; do for mode in default command-root environment-root command-shell environment-shell; do run_case "$target" "$mode"; executed=$((executed+1)); done; done; [ "$executed" -eq 40 ]
-rm -f "$LOG"; (cd "$CONTROL_DIR"&&VALLEYBOT_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" check) >/dev/null 2>&1; grep -Fq "$FAKE_PYTHON" "$LOG"; [ ! -e "$CONTROL_DIR/VALLEYBOT_ROOT_MARKER" ]; [ ! -e "$CONTROL_DIR/VALLEYBOT_PYTHON_MARKER" ]
-MARK="$TEMP_ROOT/python-syntax"; BAD="\$(shell /usr/bin/touch '$MARK')"; if (cd "$CONTROL_DIR"&&/usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$BAD" lint) >"$TEMP_ROOT/python.out" 2>&1; then exit 1; fi; [ ! -e "$MARK" ]
-ENV_MARK="$TEMP_ROOT/python-environment-syntax"; ENV_BAD="\$(shell /usr/bin/touch '$ENV_MARK')"; if (cd "$CONTROL_DIR"&&PYTHON="$ENV_BAD" /usr/bin/make --environment-overrides --no-print-directory -f "$MAKEFILE" lint) >"$TEMP_ROOT/python-environment.out" 2>&1; then exit 1; fi; [ ! -e "$ENV_MARK" ]
-if (cd "$CONTROL_DIR"&&/usr/bin/make --no-print-directory -f "$MAKEFILE" MAKEFILE_LIST=/tmp/untrusted check) >"$TEMP_ROOT/list" 2>&1; then exit 1; fi; grep -Fq 'MAKEFILE_LIST must not be overridden' "$TEMP_ROOT/list"
-if (cd "$CONTROL_DIR"&&MAKEFILE_LIST=/tmp/untrusted /usr/bin/make --environment-overrides --no-print-directory -f "$MAKEFILE" check) >"$TEMP_ROOT/list-environment" 2>&1; then exit 1; fi; grep -Fq 'MAKEFILE_LIST must not be overridden' "$TEMP_ROOT/list-environment"
-PRE="$TEMP_ROOT/pre.mk"; PRE_MARKER="$TEMP_ROOT/pre-ran"; printf '%s\n' "\$(shell /usr/bin/touch '$PRE_MARKER')" >"$PRE"; if (cd "$CONTROL_DIR"&&MAKEFILES="$PRE" /usr/bin/make --no-print-directory -f "$MAKEFILE" check) >"$TEMP_ROOT/pre" 2>&1; then exit 1; fi; grep -Fq 'MAKEFILES must be empty' "$TEMP_ROOT/pre"; [ -e "$PRE_MARKER" ]
-EARLY="$TEMP_ROOT/early.mk"; EARLY_MARKER="$TEMP_ROOT/early-ran"; printf '%s\n' "\$(shell /usr/bin/touch '$EARLY_MARKER')" >"$EARLY"; if (cd "$CONTROL_DIR"&&/usr/bin/make --no-print-directory -f "$EARLY" -f "$MAKEFILE" check) >"$TEMP_ROOT/early" 2>&1; then exit 1; fi; [ -s "$TEMP_ROOT/early" ]; [ -e "$EARLY_MARKER" ]
-if (cd "$CONTROL_DIR"&&/usr/bin/make --no-print-directory -f "$MAKEFILE" MAKEFLAGS=-n check) >"$TEMP_ROOT/flags" 2>&1; then exit 1; fi; grep -Fq 'MAKEFLAGS must not be overridden' "$TEMP_ROOT/flags"
-for flag in -n --just-print --dry-run --recon -t --touch -q --question -i --ignore-errors; do if (cd "$CONTROL_DIR"&&/usr/bin/make "$flag" --no-print-directory -f "$MAKEFILE" check) >"$TEMP_ROOT/flag" 2>&1; then exit 1; fi; grep -Fq 'non-executing or error-ignoring MAKEFLAGS are not supported' "$TEMP_ROOT/flag"; done
-printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python path, 2 raw Make-syntax rejections, 2 MAKEFILE_LIST rejections, 2 startup-boundary cases, cleanup containment, caller MAKEFLAGS rejection, and 10 mode rejections'
+
+for script in test-makefile-root.sh check_valleybot_contracts.py test_web_chat_length_contract.py prepare_nltk_data.sh; do
+    cp "$FAKE_PYTHON" "$CHECKOUT/scripts/$script"
+done
+for file in app.py bot.py bot_tests.py config.py nltk_guard.py settings.py slack_auth.py slack_replay.py slack.py; do
+    : >"$CHECKOUT/$file"
+done
+
+FAKE_SHELL="$TEMP_ROOT/fake-shell"
+cat >"$FAKE_SHELL" <<EOF
+#!/bin/sh
+printf invoked >> '$SHELL_LOG'
+exec /bin/sh "\$@"
+EOF
+chmod +x "$FAKE_SHELL"
+
+make_run() {
+    "$MAKE_BIN" --no-print-directory "$@"
+}
+
+run_case() {
+    target=$1
+    mode=$2
+    rm -f "$LOG" "$SHELL_LOG"
+    : >"$CHECKOUT/probe.pyc"
+    : >"$ATTACKER_ROOT/keep.pyc"
+    set +e
+    case "$mode" in
+        default)
+            (cd "$CONTROL_DIR" && VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1
+            ;;
+        command-root)
+            (cd "$CONTROL_DIR" && VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" ROOT="$ATTACKER_ROOT" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1
+            ;;
+        environment-root)
+            (cd "$CONTROL_DIR" && ROOT="$ATTACKER_ROOT" VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1
+            ;;
+        command-shell)
+            (cd "$CONTROL_DIR" && VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" SHELL="$FAKE_SHELL" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1
+            ;;
+        environment-shell)
+            (cd "$CONTROL_DIR" && SHELL="$FAKE_SHELL" VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1
+            ;;
+    esac
+    status=$?
+    set -e
+    [ "$status" -eq 0 ]
+    [ ! -e "$SHELL_LOG" ]
+    [ -e "$ATTACKER_ROOT/keep.pyc" ]
+    case "$target" in
+        clean) [ ! -e "$CHECKOUT/probe.pyc" ] ;;
+        *) grep -Fq "$CHECKOUT" "$LOG" ;;
+    esac
+}
+
+executed=0
+for target in build check clean lint prepare-corpora root-test test verify; do
+    for mode in default command-root environment-root command-shell environment-shell; do
+        run_case "$target" "$mode"
+        executed=$((executed + 1))
+    done
+done
+[ "$executed" -eq 40 ]
+
+rm -f "$LOG"
+(cd "$CONTROL_DIR" && VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" check) >/dev/null 2>&1
+grep -Fq "$FAKE_PYTHON" "$LOG"
+[ ! -e "$CONTROL_DIR/VALLEYBOT_ROOT_MARKER" ]
+[ ! -e "$CONTROL_DIR/VALLEYBOT_PYTHON_MARKER" ]
+
+MARK="$TEMP_ROOT/python-syntax"
+BAD="\$(shell /usr/bin/touch '$MARK')"
+if (cd "$CONTROL_DIR" && make_run -f "$MAKEFILE" "PYTHON=$BAD" lint) >"$TEMP_ROOT/python.out" 2>&1; then
+    exit 1
+fi
+[ ! -e "$MARK" ]
+
+ENV_MARK="$TEMP_ROOT/python-environment-syntax"
+ENV_BAD="\$(shell /usr/bin/touch '$ENV_MARK')"
+if (cd "$CONTROL_DIR" && PYTHON="$ENV_BAD" make_run --environment-overrides -f "$MAKEFILE" lint) >"$TEMP_ROOT/python-environment.out" 2>&1; then
+    exit 1
+fi
+[ ! -e "$ENV_MARK" ]
+
+if (cd "$CONTROL_DIR" && make_run -f "$MAKEFILE" MAKEFILE_LIST=/tmp/untrusted check) >"$TEMP_ROOT/list" 2>&1; then
+    exit 1
+fi
+grep -Fq 'MAKEFILE_LIST must not be overridden' "$TEMP_ROOT/list"
+
+if (cd "$CONTROL_DIR" && MAKEFILE_LIST=/tmp/untrusted make_run --environment-overrides -f "$MAKEFILE" check) >"$TEMP_ROOT/list-environment" 2>&1; then
+    exit 1
+fi
+grep -Fq 'MAKEFILE_LIST must not be overridden' "$TEMP_ROOT/list-environment"
+
+PRE="$TEMP_ROOT/pre.mk"
+PRE_MARKER="$TEMP_ROOT/pre-ran"
+printf '%s\n' "\$(shell /usr/bin/touch '$PRE_MARKER')" >"$PRE"
+if (cd "$CONTROL_DIR" && MAKEFILES="$PRE" make_run -f "$MAKEFILE" check) >"$TEMP_ROOT/pre" 2>&1; then
+    exit 1
+fi
+grep -Fq 'MAKEFILES must be empty' "$TEMP_ROOT/pre"
+[ -e "$PRE_MARKER" ]
+
+EARLY="$TEMP_ROOT/early.mk"
+EARLY_MARKER="$TEMP_ROOT/early-ran"
+printf '%s\n' "\$(shell /usr/bin/touch '$EARLY_MARKER')" >"$EARLY"
+if (cd "$CONTROL_DIR" && make_run -f "$EARLY" -f "$MAKEFILE" check) >"$TEMP_ROOT/early" 2>&1; then
+    exit 1
+fi
+[ -s "$TEMP_ROOT/early" ]
+[ -e "$EARLY_MARKER" ]
+
+GLOBAL_SHELL="$TEMP_ROOT/global-override-shell"
+GLOBAL_SHELL_LOG="$TEMP_ROOT/global-override-shell.log"
+GLOBAL_OVERRIDE="$TEMP_ROOT/global-override.mk"
+cat >"$GLOBAL_SHELL" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$VALLEYBOT_GLOBAL_OVERRIDE_LOG"
+printf ok
+exit 0
+EOF
+chmod +x "$GLOBAL_SHELL"
+printf 'override SHELL := %s\noverride .SHELLFLAGS := -c\n' "$GLOBAL_SHELL" >"$GLOBAL_OVERRIDE"
+if ! (cd "$CONTROL_DIR" && VALLEYBOT_GLOBAL_OVERRIDE_LOG="$GLOBAL_SHELL_LOG" make_run -f "$MAKEFILE" -f "$GLOBAL_OVERRIDE" PYTHON=/bin/false lint) >"$TEMP_ROOT/global-override" 2>&1; then
+    exit 1
+fi
+[ -s "$GLOBAL_SHELL_LOG" ]
+grep -Fq 'py_compile' "$GLOBAL_SHELL_LOG"
+
+if (cd "$CONTROL_DIR" && make_run -f "$MAKEFILE" MAKEFLAGS=-n check) >"$TEMP_ROOT/flags" 2>&1; then
+    exit 1
+fi
+grep -Fq 'MAKEFLAGS must not be overridden' "$TEMP_ROOT/flags"
+
+for flag in -n --just-print --dry-run --recon -t --touch -q --question -i --ignore-errors; do
+    if (cd "$CONTROL_DIR" && make_run "$flag" -f "$MAKEFILE" check) >"$TEMP_ROOT/flag" 2>&1; then
+        exit 1
+    fi
+    grep -Fq 'non-executing or error-ignoring MAKEFLAGS are not supported' "$TEMP_ROOT/flag"
+done
+
+printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python path, 2 raw Make-syntax rejections, 2 MAKEFILE_LIST rejections, 2 startup-boundary cases, cleanup containment, caller MAKEFLAGS rejection, global override shell boundary control showing caller global override SHELL can make a failing Python tool look successful, and 10 unsafe mode rejections'


### PR DESCRIPTION
## Summary

Historical pull request metadata normalized for engineering-bar traceability. The original description is preserved verbatim below.

## Baseline

This pull request predates the current standardized engineering-bar description format.

## Improvements

- Preserves the original code, commits, review state, and pull request state.
- Adds structured documentation headings only; no repository files or merge decisions change.

## Validation

- Confirmed pull request #28 remains open at head `3861ab2a861d29384523f8764fa1b8e758e0abf3`.
- Confirmed this edit changes only the pull request description.

## Risk

No runtime or repository risk; this is metadata-only normalization.

## Follow-Ups

PR #28 remains open and unmerged. Its original no-merge constraint is preserved verbatim below and remains authoritative.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because no repository or deployed runtime content changed.

## Original PR Description

## Summary

- document the enforceable repository-controlled Make boundary
- add executable coverage for caller-owned GNU Make programs and tools
- synchronize the Valleybot contract baseline with that narrowed boundary

## Truthful caller Make boundary

Repository-controlled Make verification assumes the reviewed Makefile is loaded without caller-supplied Make programs or tools.

The following remain caller authority and are explicitly outside the local Make trust boundary: `MAKEFILES` startup files, additional `-f` makefiles, global or target-specific `override` directives, replacement or double-colon recipes, and caller-selected `SHELL`, `.SHELLFLAGS`, `PATH`, Python, or other tool variables.

The focused harness reproduces the prior exact blocker: a later global `override SHELL` can spoof the guard's shell result and make a failing Python tool appear successful. This is now tested and documented as caller authority rather than represented as a repository-enforceable security guarantee.

## Cross-version and test evidence

The authority harness passed under system GNU Make 3.81 and GNU Make 4.3 with byte-identical logs. SHA-256:

`2d03f315c5c95b8c13446a3f294d4b216ebd76e8212555140533c6f93ad13de0`

Canonical and external-directory `make check` both passed with a literal Python interpreter from an isolated environment. Each run completed:

- 71 Valleybot contract tests
- five web-chat mutation rejections
- 41 real `bot_tests` unit tests
- the full authority, compilation, and cleanup gates

## Preserved scope

Application/runtime modules, `bot_tests.py`, dependency pins, checked-in NLTK corpora, workflows, Procfile/app metadata, templates, SECURITY, VISION, and AGENTS are unchanged from current `master`.

Current-tree gitleaks 8.30.1 scanned approximately 117 MB and found no leaks. The history-mode gitleaks scan was interrupted during independent checkpointing after the successful current-tree scan and was not rerun; this limitation must remain visible during hosted review.

Local NLTK network refresh attempts encountered host TLS certificate errors, but checked-in corpora satisfied all tests and both complete Make checks exited successfully.

This PR is solely for hosted validation. It carries no approval or merge authorization. Auto-merge must remain disabled; do not merge based on this publication action alone.

