### PR TITLE
fix: keep NLTK gates project-local

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 - Baked an absolute Python interpreter into verification recipes, rejected
   PATH-shadowed defaults and later shell false-success, and isolated startup
   from `PYTHONPATH`, user-site packages, and `sitecustomize.py`.
+- Made Make and Heroku corpus preparation use and verify the same
+  project-local NLTK data directory.
 
 - Guarded NLTK resource loading against URL-encoded absolute and parent-path
   traversal while preserving fixed TextBlob corpus names, with runtime and

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ifneq ($(origin MAKEFILE_LIST),file)
 $(error MAKEFILE_LIST must not be overridden)
 endif
 override REPOSITORY_MAKEFILE_LIST := $(value MAKEFILE_LIST)
-override ROOT := $(shell path='$(subst ','"'"',$(value MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+override ROOT := $(shell path='$(subst ','"'"',$(value MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH='' cd -- "$$directory" && /bin/pwd -P)
 export ROOT
 ifeq ($(strip $(ROOT)),)
 $(error repository Makefile path could not be resolved)
@@ -74,6 +74,7 @@ PYTHON_FILES := \
 	slack_auth.py \
 	slack_replay.py \
 	slack.py \
+	scripts/check_nltk_data.py \
 	scripts/check_valleybot_contracts.py \
 	scripts/test_web_chat_length_contract.py
 
@@ -94,7 +95,7 @@ lint::
 	cd '$(REPOSITORY_ROOT_LITERAL)' && PYTHONDONTWRITEBYTECODE=1 '$(REPOSITORY_PYTHON_LITERAL)' -I -B -m py_compile $(PYTHON_FILES)
 
 prepare-corpora::
-	REPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/run-python.sh' --module textblob.download_corpora lite
+	REPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/prepare_nltk_data.sh'
 
 test:: prepare-corpora
 	REPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/run-python.sh' '$(REPOSITORY_ROOT_LITERAL)/scripts/check_valleybot_contracts.py'

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   reject PATH-shadowed defaults, and use isolated Python startup (`-I -B`) to
   ignore `PYTHONPATH`, user-site packages, and `sitecustomize.py`. Hosted checks
   invoke `/usr/bin/make` explicitly without additional Make programs.
-- `make prepare-corpora` installs the current TextBlob tokenizer and tagger
-  data into the existing project-local `nltk_data` directory. Heroku runs the
-  same step through `bin/post_compile`.
+- `make prepare-corpora` installs and verifies the current TextBlob tokenizer
+  and tagger data in the existing project-local `nltk_data` directory. Heroku
+  runs the same step through `bin/post_compile`.
 - `python scripts/check_valleybot_contracts.py` runs just the webhook and token-handling contracts.
 - GitHub Actions installs dependencies and runs the complete gate on Python
   3.10, 3.12, and 3.14 on Ubuntu 24.04 with read-only permissions, immutable

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 REPOSITORY_PYTHON=$(command -v python)
 export REPOSITORY_PYTHON
 "$ROOT_DIR/scripts/prepare_nltk_data.sh"

--- a/scripts/check_nltk_data.py
+++ b/scripts/check_nltk_data.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Verify TextBlob/NLTK runtime data is present in the project data directory."""
+import os
+from pathlib import Path
+
+import nltk.data
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_NLTK_DATA = (ROOT / "nltk_data").resolve()
+REQUIRED_RESOURCES = (
+    "corpora/brown",
+    "tokenizers/punkt_tab",
+    "corpora/wordnet",
+    "taggers/averaged_perceptron_tagger_eng",
+)
+
+
+def _resource_path(pointer):
+    location = str(pointer)
+    if ".zip" in location:
+        location = location.split(".zip", 1)[0] + ".zip"
+    return Path(location).resolve()
+
+
+def main():
+    configured = Path(os.environ.get("NLTK_DATA", "")).resolve()
+    if configured != EXPECTED_NLTK_DATA:
+        raise SystemExit(
+            "NLTK_DATA must be the project-local directory: {0}".format(
+                EXPECTED_NLTK_DATA
+            )
+        )
+
+    missing = []
+    for resource in REQUIRED_RESOURCES:
+        try:
+            found = _resource_path(nltk.data.find(resource))
+        except LookupError:
+            missing.append("{0} is missing".format(resource))
+            continue
+
+        if found != EXPECTED_NLTK_DATA and EXPECTED_NLTK_DATA not in found.parents:
+            missing.append("{0} resource is outside NLTK_DATA: {1}".format(resource, found))
+
+    if missing:
+        raise SystemExit("missing NLTK resource(s): {0}".format("; ".join(missing)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -614,6 +614,81 @@ def test_nltk_resource_path_guard_contracts():
     )
 
 
+def test_shell_entrypoints_use_portable_cdpath_reset():
+    for relative_path in (
+        "bin/post_compile",
+        "scripts/prepare_nltk_data.sh",
+        "scripts/run-python.sh",
+    ):
+        source = (ROOT / relative_path).read_text(encoding="utf-8")
+        assert_true(
+            "CDPATH= cd --" not in source,
+            "{0} must not use shellcheck SC1007-prone CDPATH= cd form".format(
+                relative_path
+            ),
+        )
+        assert_true(
+            "CDPATH='' cd --" in source or "CDPATH=; cd --" in source,
+            "{0} must reset CDPATH portably before resolving the repository".format(
+                relative_path
+            ),
+        )
+
+
+def test_prepare_corpora_uses_project_local_nltk_data_contract():
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    prepare_script = (ROOT / "scripts" / "prepare_nltk_data.sh").read_text(
+        encoding="utf-8"
+    )
+    nltk_checker = (ROOT / "scripts" / "check_nltk_data.py").read_text(
+        encoding="utf-8"
+    )
+    post_compile = (ROOT / "bin" / "post_compile").read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert_true(
+        "scripts/prepare_nltk_data.sh" in makefile,
+        "make prepare-corpora must use the reviewed project-local NLTK entrypoint",
+    )
+    assert_true(
+        "prepare-corpora::\n\tREPOSITORY_PYTHON=" in makefile,
+        "make prepare-corpora must bake the reviewed Python interpreter",
+    )
+    assert_true(
+        'export NLTK_DATA="$ROOT_DIR/nltk_data"' in prepare_script,
+        "prepare_nltk_data.sh must target project-local nltk_data",
+    )
+    assert_true(
+        "scripts/check_nltk_data.py" in prepare_script,
+        "prepare_nltk_data.sh must verify project-local runtime resources",
+    )
+    for resource in (
+        "corpora/brown",
+        "tokenizers/punkt_tab",
+        "corpora/wordnet",
+        "taggers/averaged_perceptron_tagger_eng",
+    ):
+        assert_true(
+            resource in nltk_checker,
+            "NLTK data checker must require {0}".format(resource),
+        )
+    assert_true(
+        "resource is outside NLTK_DATA" in nltk_checker,
+        "NLTK data checker must require resources from project-local NLTK_DATA",
+    )
+    assert_true(
+        '"$ROOT_DIR/scripts/prepare_nltk_data.sh"' in post_compile,
+        "post_compile must use the same project-local NLTK entrypoint",
+    )
+    normalized_readme = " ".join(readme.split())
+    assert_true(
+        "`make prepare-corpora` installs and verifies the current TextBlob tokenizer "
+        "and tagger data in the existing project-local `nltk_data` directory"
+        in normalized_readme,
+        "README must truthfully describe make prepare-corpora resource path",
+    )
+
+
 def test_messenger_post_rejects_oversized_declared_body():
     app, request, response, requests = load_app()
     request.content_length = app.MAX_MESSENGER_WEBHOOK_BYTES + 1
@@ -1907,6 +1982,8 @@ def main():
         test_runtime_and_ci_contracts,
         test_make_authority_boundary_is_truthful,
         test_nltk_resource_path_guard_contracts,
+        test_shell_entrypoints_use_portable_cdpath_reset,
+        test_prepare_corpora_uses_project_local_nltk_data_contract,
         test_messenger_post_rejects_oversized_declared_body,
         test_messenger_post_rejects_oversized_streamed_body,
         test_messenger_post_rejects_invalid_signature,

--- a/scripts/prepare_nltk_data.sh
+++ b/scripts/prepare_nltk_data.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 export NLTK_DATA="$ROOT_DIR/nltk_data"
 
 : "${REPOSITORY_PYTHON:?REPOSITORY_PYTHON must name the reviewed absolute interpreter}"
 "$ROOT_DIR/scripts/run-python.sh" --module textblob.download_corpora lite
+"$ROOT_DIR/scripts/run-python.sh" "$ROOT_DIR/scripts/check_nltk_data.py"

--- a/scripts/run-python.sh
+++ b/scripts/run-python.sh
@@ -8,7 +8,7 @@ case $REPOSITORY_PYTHON in
     *) printf '%s\n' 'REPOSITORY_PYTHON must be an absolute path' >&2; exit 2 ;;
 esac
 
-root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
+root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
 
 if [ "${1-}" = --module ]; then
     shift


### PR DESCRIPTION
## Summary
- Fix the SC1007-prone shell root entrypoint pattern portably.
- Keep NLTK corpora preparation project-local across the Make and Heroku entrypoints.
- Add executable path assertions so repository gates fail closed if NLTK/TextBlob resolves corpora outside the checked-out `nltk_data` tree.

## Validation
- Independent read-only review completed against `a824739e20bb1a32f5d005dea2790efda620032d` / tree `b58b102f5944beee2032e076e8fee5fae53c74e9`.
- Python 3.12 evidence: canonical and external-cwd `make check` passed under the reviewed Make authority matrix.
- Python 3.14 evidence: canonical and external-cwd `make check` passed where available in the reviewed matrix.
- Shellcheck/actionlint/Gitleaks/static diff/fsck closeout completed during review.

## Scope and boundary
- Bot runtime behavior is unchanged.
- Slack/Messenger credential handling is unchanged.
- Dependency locks are unchanged.
- This PR only changes the shell/NLTK gate behavior and its executable contract; hosted validation should confirm the full configured Python matrix.
