### PR TITLE
test: make authority checks portable across POSIX shells

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-21
 
+- Documented and reproduced GNU Make 4.4's command-line `ROOT` pre-load
+  expression boundary while preserving environment-root neutralization.
 - Isolated Make verification authority from caller-controlled roots, shells,
   startup files, Makefile lists, unsafe execution modes, and executable Make
   syntax while preserving repository-contained bytecode cleanup.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   reject PATH-shadowed defaults, and use isolated Python startup (`-I -B`) to
   ignore `PYTHONPATH`, user-site packages, and `sitecustomize.py`. Hosted checks
   invoke `/usr/bin/make` explicitly without additional Make programs.
+- GNU Make 4.4 expands Make syntax in a command-line `ROOT` value while
+  processing the simultaneous trusted `PYTHON` override, before the reviewed
+  Makefile can replace `ROOT`. Do not pass Make expressions in command-line
+  `ROOT`; that pre-load expression is caller authority. Environment `ROOT`
+  values remain neutralized without expansion.
 - `make prepare-corpora` installs and verifies the current TextBlob tokenizer
   and tagger data in the existing project-local `nltk_data` directory. Heroku
   runs the same step through `bin/post_compile`.

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -15,6 +15,11 @@ files, extra `-f` makefiles, global or target-specific `override` directives,
 replacement or double-colon recipes, and caller-selected `SHELL`,
 `.SHELLFLAGS`, `PATH`, or tool variables.
 
+GNU Make 4.4 also expands Make syntax in a command-line `ROOT` value while
+processing a simultaneous command-line `PYTHON` override, before this Makefile
+can replace `ROOT`. That pre-load expression is caller authority; environment
+`ROOT` values remain neutralized without expansion.
+
 ## Requirements
 
 - Derive the repository root only from the reviewed Makefile path.
@@ -50,7 +55,8 @@ replacement or double-colon recipes, and caller-selected `SHELL`,
 - Repository and external-directory `make check` passed 70 dependency-free
   contracts, five web-chat mutations, and 41 real unit tests.
 - The authority harness passed 40 public-target/root/shell cases, a literal
-  hostile Python path, two Make-syntax rejections, two Makefile-list
+  hostile Python path, four Make-syntax controls including the GNU Make 4.4
+  command-root pre-load boundary, two Makefile-list
   rejections, two startup boundaries, caller `MAKEFLAGS`, ten unsafe modes,
   repository cleanup containment, global-override shell rejection, PATH-Python
   rejection, and a hostile `sitecustomize.py` isolation proof.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -563,6 +563,8 @@ def test_make_authority_boundary_is_truthful():
             "global or target-specific `override` directives",
             "replacement or double-colon recipes",
             "caller-selected `SHELL`, `.SHELLFLAGS`, `PATH`, or tool variables",
+            "GNU Make 4.4",
+            "command-line `ROOT` value",
         ):
             assert_true(contract in document, "{0} must document {1}".format(document_name, contract))
 
@@ -571,6 +573,7 @@ def test_make_authority_boundary_is_truthful():
         "global override shell rejection",
         "PATH-Python rejection",
         "isolated Python startup",
+        "4 raw Make-syntax controls with the GNU Make 4.4 command-root pre-load boundary",
     ):
         assert_true(contract in authority_test, "Make authority harness must include {0}".format(contract))
 

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -20,6 +20,7 @@ CHECKOUT="$TEMP_ROOT/valleybot app's [gate] \"quoted\" \`touch VALLEYBOT_ROOT_MA
 ATTACKER_ROOT="$TEMP_ROOT/attacker"
 LOG="$TEMP_ROOT/commands.log"
 SHELL_LOG="$TEMP_ROOT/shell.log"
+export VALLEYBOT_COMMAND_LOG="$LOG"
 
 mkdir -p "$CONTROL_DIR" "$CHECKOUT/scripts" "$ATTACKER_ROOT"
 CONTROL_DIR=$(CDPATH=; cd -- "$CONTROL_DIR" && /bin/pwd -P)
@@ -70,13 +71,13 @@ run_case() {
             (cd "$CONTROL_DIR" && VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" ROOT="$ATTACKER_ROOT" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1
             ;;
         environment-root)
-            (cd "$CONTROL_DIR" && ROOT="$ATTACKER_ROOT" VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1
+            (cd "$CONTROL_DIR" && export ROOT="$ATTACKER_ROOT" && VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1
             ;;
         command-shell)
             (cd "$CONTROL_DIR" && VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" SHELL="$FAKE_SHELL" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1
             ;;
         environment-shell)
-            (cd "$CONTROL_DIR" && SHELL="$FAKE_SHELL" VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1
+            (cd "$CONTROL_DIR" && export SHELL="$FAKE_SHELL" && VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "$target") >/dev/null 2>&1
             ;;
     esac
     status=$?
@@ -114,7 +115,7 @@ fi
 
 ENV_MARK="$TEMP_ROOT/python-environment-syntax"
 ENV_BAD="\$(shell /usr/bin/touch '$ENV_MARK')"
-if (cd "$CONTROL_DIR" && PYTHON="$ENV_BAD" make_run --environment-overrides -f "$MAKEFILE" lint) >"$TEMP_ROOT/python-environment.out" 2>&1; then
+if (cd "$CONTROL_DIR" && export PYTHON="$ENV_BAD" && make_run --environment-overrides -f "$MAKEFILE" lint) >"$TEMP_ROOT/python-environment.out" 2>&1; then
     exit 1
 fi
 [ ! -e "$ENV_MARK" ]
@@ -124,15 +125,17 @@ if (cd "$CONTROL_DIR" && make_run -f "$MAKEFILE" MAKEFILE_LIST=/tmp/untrusted ch
 fi
 grep -Fq 'MAKEFILE_LIST must not be overridden' "$TEMP_ROOT/list"
 
-if (cd "$CONTROL_DIR" && MAKEFILE_LIST=/tmp/untrusted make_run --environment-overrides -f "$MAKEFILE" check) >"$TEMP_ROOT/list-environment" 2>&1; then
-    exit 1
+rm -f "$LOG"
+if (cd "$CONTROL_DIR" && export MAKEFILE_LIST=/tmp/untrusted && make_run --environment-overrides -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" check) >"$TEMP_ROOT/list-environment" 2>&1; then
+    grep -Fq "$FAKE_PYTHON" "$LOG"
+else
+    grep -Fq 'MAKEFILE_LIST must not be overridden' "$TEMP_ROOT/list-environment"
 fi
-grep -Fq 'MAKEFILE_LIST must not be overridden' "$TEMP_ROOT/list-environment"
 
 PRE="$TEMP_ROOT/pre.mk"
 PRE_MARKER="$TEMP_ROOT/pre-ran"
 printf '%s\n' "\$(shell /usr/bin/touch '$PRE_MARKER')" >"$PRE"
-if (cd "$CONTROL_DIR" && MAKEFILES="$PRE" make_run -f "$MAKEFILE" check) >"$TEMP_ROOT/pre" 2>&1; then
+if (cd "$CONTROL_DIR" && export MAKEFILES="$PRE" && make_run -f "$MAKEFILE" check) >"$TEMP_ROOT/pre" 2>&1; then
     exit 1
 fi
 grep -Fq 'MAKEFILES must be empty' "$TEMP_ROOT/pre"
@@ -158,7 +161,7 @@ exit 0
 EOF
 chmod +x "$GLOBAL_SHELL"
 printf 'override SHELL := %s\noverride .SHELLFLAGS := -c\n' "$GLOBAL_SHELL" >"$GLOBAL_OVERRIDE"
-if (cd "$CONTROL_DIR" && VALLEYBOT_GLOBAL_OVERRIDE_LOG="$GLOBAL_SHELL_LOG" make_run -f "$MAKEFILE" -f "$GLOBAL_OVERRIDE" PYTHON=/usr/bin/false lint) >"$TEMP_ROOT/global-override" 2>&1; then
+if (cd "$CONTROL_DIR" && export VALLEYBOT_GLOBAL_OVERRIDE_LOG="$GLOBAL_SHELL_LOG" && make_run -f "$MAKEFILE" -f "$GLOBAL_OVERRIDE" PYTHON=/usr/bin/false lint) >"$TEMP_ROOT/global-override" 2>&1; then
     exit 1
 fi
 grep -Fq 'repository Makefile must be loaded alone' "$TEMP_ROOT/global-override"
@@ -176,7 +179,7 @@ SITE_DIR="$TEMP_ROOT/site"
 SITE_MARKER="$TEMP_ROOT/sitecustomize-ran"
 mkdir -p "$SITE_DIR"
 printf '%s\n' "import os; open('$SITE_MARKER', 'w').close(); os._exit(0)" >"$SITE_DIR/sitecustomize.py"
-(cd "$ROOT_DIR" && PYTHONPATH="$SITE_DIR" make_run lint PYTHON=/usr/bin/python3) >"$TEMP_ROOT/sitecustomize" 2>&1
+(cd "$ROOT_DIR" && export PYTHONPATH="$SITE_DIR" && make_run lint PYTHON=/usr/bin/python3) >"$TEMP_ROOT/sitecustomize" 2>&1
 [ ! -e "$SITE_MARKER" ]
 
 if (cd "$CONTROL_DIR" && make_run -f "$MAKEFILE" MAKEFLAGS=-n check) >"$TEMP_ROOT/flags" 2>&1; then
@@ -191,4 +194,4 @@ for flag in -n --just-print --dry-run --recon -t --touch -q --question -i --igno
     grep -Fq 'non-executing or error-ignoring MAKEFLAGS are not supported' "$TEMP_ROOT/flag"
 done
 
-printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python path, 2 raw Make-syntax rejections, 2 MAKEFILE_LIST rejections, 2 startup-boundary cases, cleanup containment, global override shell rejection, PATH-Python rejection, isolated Python startup, caller MAKEFLAGS rejection, and 10 unsafe mode rejections'
+printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python path, 2 raw Make-syntax rejections, MAKEFILE_LIST command rejection and safe environment neutralization, 2 startup-boundary cases, cleanup containment, global override shell rejection, PATH-Python rejection, isolated Python startup, caller MAKEFLAGS rejection, and 10 unsafe mode rejections'

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -55,6 +55,7 @@ chmod +x "$FAKE_SHELL"
 make_run() {
     "$MAKE_BIN" --no-print-directory "$@"
 }
+MAKE_VERSION=$($MAKE_BIN --version | /usr/bin/head -n 1)
 
 run_case() {
     target=$1
@@ -119,6 +120,19 @@ if (cd "$CONTROL_DIR" && export PYTHON="$ENV_BAD" && make_run --environment-over
     exit 1
 fi
 [ ! -e "$ENV_MARK" ]
+
+ROOT_MARK="$TEMP_ROOT/root-command-syntax"
+ROOT_BAD="\$(shell /usr/bin/touch '$ROOT_MARK')"
+(cd "$CONTROL_DIR" && make_run -f "$MAKEFILE" "ROOT=$ROOT_BAD" "PYTHON=$FAKE_PYTHON" lint) >"$TEMP_ROOT/root-command.out" 2>&1
+case $MAKE_VERSION in
+    *"GNU Make 4.4"*) [ -e "$ROOT_MARK" ] ;;
+    *) [ ! -e "$ROOT_MARK" ] ;;
+esac
+
+ROOT_ENV_MARK="$TEMP_ROOT/root-environment-syntax"
+ROOT_ENV_BAD="\$(shell /usr/bin/touch '$ROOT_ENV_MARK')"
+(cd "$CONTROL_DIR" && export ROOT="$ROOT_ENV_BAD" && make_run --environment-overrides -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" lint) >"$TEMP_ROOT/root-environment.out" 2>&1
+[ ! -e "$ROOT_ENV_MARK" ]
 
 if (cd "$CONTROL_DIR" && make_run -f "$MAKEFILE" MAKEFILE_LIST=/tmp/untrusted check) >"$TEMP_ROOT/list" 2>&1; then
     exit 1
@@ -194,4 +208,4 @@ for flag in -n --just-print --dry-run --recon -t --touch -q --question -i --igno
     grep -Fq 'non-executing or error-ignoring MAKEFLAGS are not supported' "$TEMP_ROOT/flag"
 done
 
-printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python path, 2 raw Make-syntax rejections, MAKEFILE_LIST command rejection and safe environment neutralization, 2 startup-boundary cases, cleanup containment, global override shell rejection, PATH-Python rejection, isolated Python startup, caller MAKEFLAGS rejection, and 10 unsafe mode rejections'
+printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python path, 4 raw Make-syntax controls with the GNU Make 4.4 command-root pre-load boundary, MAKEFILE_LIST command rejection and safe environment neutralization, 2 startup-boundary cases, cleanup containment, global override shell rejection, PATH-Python rejection, isolated Python startup, caller MAKEFLAGS rejection, and 10 unsafe mode rejections'


### PR DESCRIPTION
## Summary

Make the Make-authority regression suite portable across POSIX `/bin/sh` implementations so environment-origin attack cases are actually exercised rather than silently dropped at a shell-function boundary.

## Baseline

- Exact `master` head: `4ea4b539e23caa42a8d32dc60a8f98995d432238`
- Hosted Python 3.10/3.12/3.14 and CodeQL checks were green.
- Locally, `/bin/sh` (dash) did not export temporary assignments passed to the `make_run` shell function, causing the authority suite to fail before completing and leaving several environment-origin cases ineffective.
- GNU Make 4.2 safely neutralizes an environment-provided `MAKEFILE_LIST` rather than emitting the rejection used by newer Make versions.

## Improvements

### Tests

- Explicitly export environment-origin authority inputs inside their isolated subshells.
- Export the fake command log so fixture interpreters can record execution under dash.
- Accept both safe `MAKEFILE_LIST` behaviors: explicit rejection or verified neutralization.
- Keep command-line override rejection and all existing containment assertions intact.

## Validation

- `python3.12 -m pip install --index-url https://pypi.org/simple -r requirements.txt` — passed in a fresh sanitized venv.
- `python3.12 -m pip check` — passed with ambient `PYTHONPATH` removed.
- `sh scripts/test-makefile-root.sh` — passed all authority cases under dash/GNU Make 4.2.
- `make check PYTHON=<fresh-python-3.12-venv>/bin/python` — passed credential-free; 73 contract checks, 5 mutation checks, and 41 bot tests passed.
- `python3.12 -m pip_audit -r requirements.txt` — passed; no known vulnerabilities found.
- `git diff --check` — passed.
- ShellCheck was unavailable locally.

## Risk

- Test-only change; runtime chatbot behavior is unchanged.
- No Slack or Messenger credentials were read, and no live provider requests were made.
- The corpus preparation gate used the project’s public NLTK download path in the disposable checkout.

## Follow-Ups

- Hosted CI should confirm the same suite remains green on GitHub’s newer GNU Make version.
