### PR TITLE
Preserve in-flight Messenger replay claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@
 - `MESSENGER_VERIFY_TOKEN` configures Messenger webhook verification; missing
   values fail closed and never fall back to `MESSENGER_TOKEN`.
 - `REQUEST_TIMEOUT` optionally overrides outbound Messenger request timeout seconds; invalid, non-finite, or non-positive values fall back to `5.0`.
+- In-flight Messenger message-ID claims are never capacity-evicted; only
+  completed claims enter the bounded replay cache.
 - Preserve punctuation and non-space whitespace token boundaries in the final
   response filter; changes to moderation text still require human review.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,32 @@
 # Changes
 
+## 2026-06-25T21:16:14Z — P1 concurrency/correctness — cycle: Messenger in-flight replay claims
+
+- Threads: inspected the explicit Apache 2.0 license, default branch, open pull
+  requests and issues, hosted checks, Messenger signature and media-type gates,
+  batch ordering, provider failure release, message-ID replay state, Slack
+  replay state, outbound timeouts, runtime tests, and dependency-free contracts.
+- Bug fixed: replay-cache capacity can no longer evict an in-flight Messenger
+  message ID while its outbound reply is pending, preventing a concurrent retry
+  from generating a duplicate reply.
+- Files: `app.py`, `scripts/check_valleybot_contracts.py`, replay security and
+  maintenance documentation, and
+  `docs/plans/2026-06-25-messenger-inflight-replay-claims.md`.
+- Validation: reproduced the missing completion state as an `AttributeError`,
+  then passed seventy-four dependency-free contracts, forty-three Bottle/bot
+  runtime tests, five web-chat mutations, full Python 3.14 `make check`, and
+  dependency compatibility checks.
+- Blockers: no live Messenger webhook or provider request was sent; hosted
+  Python 3.10/3.12/3.14 verification remains required before merge.
+- Next: load-test concurrent signed retries near replay-cache capacity and
+  evaluate a shared durable replay store for multi-worker deployments.
+
 ## 2026-06-25
 
 - Hardened final-output moderation tokenization across punctuation and
   non-space whitespace boundaries without changing reviewed response or
   blocklist content.
+- In-flight Messenger message-ID claims are never capacity-evicted; only completed claims enter the bounded replay cache.
 
 ## 2026-06-21
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   execution-authority and cleanup-containment boundary.
 - See `docs/plans/2026-06-13-messenger-message-replay-guard.md` for the bounded
   process-local Messenger retry guard.
+- In-flight Messenger message-ID claims are never capacity-evicted; only
+  completed claims enter the bounded replay cache.
+- See `docs/plans/2026-06-25-messenger-inflight-replay-claims.md` for the
+  concurrent replay-claim lifecycle.
 - See `docs/plans/2026-06-13-messenger-batch-processing-bound.md` for ordered,
   capped multi-message webhook processing.
 - See `docs/plans/2026-06-17-web-chat-input-length.md` for the public web-chat

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,10 +50,12 @@ verification, JSON parsing, response generation, or outbound API calls.
 Messenger POST requests must use the `application/json` media type; optional
 parameters and case differences are accepted, while other types return 415
 before signature verification or JSON parsing.
-Recent non-empty Messenger message IDs are claimed before outbound replies in a
-bounded process-local cache. Duplicate deliveries are acknowledged without a
-second reply, and outbound exceptions release their claim. This protection
-does not span multiple workers or process restarts.
+Recent non-empty Messenger message IDs are claimed before outbound replies in
+process-local state. Successful replies move their IDs into a bounded completed
+cache; duplicate deliveries are acknowledged without a second reply, and
+outbound exceptions release their claim. This protection does not span multiple
+workers or process restarts.
+In-flight Messenger message-ID claims are never capacity-evicted; only completed claims enter the bounded replay cache.
 Provider HTTP errors propagate through the webhook handler and release any
 message-ID claim so a later provider delivery can retry the outbound reply.
 Each signed webhook processes at most 20 valid user messages in payload order,

--- a/VISION.md
+++ b/VISION.md
@@ -28,6 +28,7 @@ Priority:
 - Reject blank or non-text Messenger messages before response generation
 - Suppress duplicate Messenger replies from retried message IDs with bounded
   process-local state
+- In-flight Messenger message-ID claims are never capacity-evicted; only completed claims enter the bounded replay cache.
 - Process Messenger message batches in order with a fixed per-webhook cap
 - Keep Messenger reply behavior independent of client-controlled debug fields
 - Fail Messenger replies on provider HTTP errors so webhook retries remain

--- a/app.py
+++ b/app.py
@@ -27,21 +27,28 @@ MAX_WEB_CHAT_CHARACTERS = 1000
 class RecentMessageIds(object):
     def __init__(self, max_entries):
         self.max_entries = max_entries
-        self._ids = OrderedDict()
+        self._inflight = set()
+        self._completed = OrderedDict()
         self._lock = threading.Lock()
 
     def claim(self, message_id):
         with self._lock:
-            if message_id in self._ids:
+            if message_id in self._inflight or message_id in self._completed:
                 return False
-            self._ids[message_id] = None
-            while len(self._ids) > self.max_entries:
-                self._ids.popitem(last=False)
+            self._inflight.add(message_id)
             return True
+
+    def complete(self, message_id):
+        with self._lock:
+            self._inflight.discard(message_id)
+            self._completed[message_id] = None
+            while len(self._completed) > self.max_entries:
+                self._completed.popitem(last=False)
 
     def release(self, message_id):
         with self._lock:
-            self._ids.pop(message_id, None)
+            self._inflight.discard(message_id)
+            self._completed.pop(message_id, None)
 
 
 recent_messenger_message_ids = RecentMessageIds(
@@ -158,6 +165,8 @@ def messenger_post():
             continue
         try:
             messenger_reply(sender, message)
+            if message_id:
+                recent_messenger_message_ids.complete(message_id)
         except Exception:
             if message_id:
                 recent_messenger_message_ids.release(message_id)

--- a/docs/plans/2026-06-25-messenger-inflight-replay-claims.md
+++ b/docs/plans/2026-06-25-messenger-inflight-replay-claims.md
@@ -1,0 +1,25 @@
+# Messenger In-Flight Replay Claims
+
+Status: Completed
+
+## Problem
+
+The bounded message-ID cache treated pending and successful replies identically.
+When capacity eviction removed the oldest pending ID, a concurrent delivery of
+that same signed message could claim it again before the first outbound reply
+finished, producing duplicate bot replies.
+
+## Change
+
+Track in-flight IDs separately from completed IDs. Claims stay protected until
+the outbound reply succeeds or fails. Success moves the ID into the bounded
+completed replay cache; failure releases it for provider retry recovery.
+
+## Verification
+
+- RED reproduced as an `AttributeError` for the missing `complete()` transition.
+- Added bounded completed-claim eviction coverage.
+- Added a capacity-pressure regression proving an in-flight ID cannot be reclaimed.
+- Kept claim, reply, completion, and failure-release ordering under source checks.
+- Dependency-free contracts and the full `make check` passed.
+- No live Messenger webhook or provider request was sent.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -1218,10 +1218,28 @@ def test_recent_message_ids_evicts_oldest_claims_at_bound():
     recent = app.RecentMessageIds(2)
 
     assert_true(recent.claim("mid-1"), "first replay claim")
+    recent.complete("mid-1")
     assert_true(recent.claim("mid-2"), "second replay claim")
+    recent.complete("mid-2")
     assert_true(recent.claim("mid-3"), "third replay claim")
+    recent.complete("mid-3")
     assert_true(not recent.claim("mid-3"), "newest replay claim must remain protected")
     assert_true(recent.claim("mid-1"), "oldest replay claim must be evicted")
+
+
+def test_recent_message_ids_never_evicts_inflight_claims():
+    app, _request, _response, _requests = load_app()
+    recent = app.RecentMessageIds(2)
+
+    assert_true(recent.claim("mid-inflight"), "in-flight replay claim")
+    for message_id in ("mid-1", "mid-2", "mid-3"):
+        assert_true(recent.claim(message_id), "completed replay claim")
+        recent.complete(message_id)
+
+    assert_true(
+        not recent.claim("mid-inflight"),
+        "capacity eviction must not release an in-flight replay claim",
+    )
 
 
 def test_messenger_post_releases_claim_when_reply_fails():
@@ -1261,16 +1279,37 @@ def test_messenger_replay_source_contracts():
             "MAX_RECENT_MESSENGER_MESSAGE_IDS = 1024",
             "class RecentMessageIds(object):",
             "self._lock = threading.Lock()",
-            "self._ids.popitem(last=False)",
+            "self._inflight = set()",
+            "self._completed = OrderedDict()",
+            "self._completed.popitem(last=False)",
             "message_id = message.get('mid')",
             "recent_messenger_message_ids.claim(message_id)",
+            "recent_messenger_message_ids.complete(message_id)",
             "recent_messenger_message_ids.release(message_id)"):
         assert_true(contract in source, "missing Messenger replay contract {0}".format(contract))
 
     claim_position = source.index("recent_messenger_message_ids.claim(message_id)")
     reply_position = source.index("messenger_reply(sender, message)")
+    complete_position = source.index("recent_messenger_message_ids.complete(message_id)")
     release_position = source.index("recent_messenger_message_ids.release(message_id)")
-    assert_true(claim_position < reply_position < release_position, "claim, reply, and failure release must stay ordered")
+    assert_true(
+        claim_position < reply_position < complete_position < release_position,
+        "claim, reply, completion, and failure release must stay ordered",
+    )
+
+    guidance = (
+        "In-flight Messenger message-ID claims are never capacity-evicted; "
+        "only completed claims enter the bounded replay cache."
+    )
+    for relative_path in ("README.md", "SECURITY.md", "VISION.md", "CHANGES.md"):
+        document = " ".join(
+            (ROOT / relative_path).read_text(encoding="utf-8").split()
+        )
+        assert_true(guidance in document, "{0} must document in-flight replay claims".format(relative_path))
+    assert_completed_plan(
+        ROOT / "docs" / "plans" / "2026-06-25-messenger-inflight-replay-claims.md",
+        "Messenger in-flight replay claim",
+    )
 
 
 def test_messenger_batch_source_contracts():
@@ -1298,10 +1337,12 @@ def test_messenger_batch_source_contracts():
     loop_position = source.index("for sender, message, message_id in messages:")
     claim_position = source.index("recent_messenger_message_ids.claim(message_id)", loop_position)
     reply_position = source.index("messenger_reply(sender, message)", loop_position)
+    complete_position = source.index("recent_messenger_message_ids.complete(message_id)", loop_position)
     release_position = source.index("recent_messenger_message_ids.release(message_id)", loop_position)
     assert_true(
-        parse_position < loop_position < claim_position < reply_position < release_position,
-        "bounded extraction and per-message claim, reply, and release must stay ordered",
+        parse_position < loop_position < claim_position < reply_position <
+        complete_position < release_position,
+        "bounded extraction and per-message claim, reply, completion, and release must stay ordered",
     )
 
     docs = {
@@ -2053,6 +2094,7 @@ def main():
         test_messenger_post_suppresses_replayed_message_ids,
         test_messenger_post_preserves_messages_without_ids,
         test_recent_message_ids_evicts_oldest_claims_at_bound,
+        test_recent_message_ids_never_evicts_inflight_claims,
         test_messenger_post_releases_claim_when_reply_fails,
         test_messenger_post_ignores_malformed_message_ids_for_compatibility,
         test_messenger_replay_source_contracts,


### PR DESCRIPTION
## Summary
- separate in-flight Messenger message IDs from the bounded completed replay cache
- retain pending claims across completed-cache capacity eviction
- move IDs to completed state only after a successful provider reply
- preserve failure release so provider retries remain recoverable

## Validation
- RED: dependency-free contracts failed with `AttributeError` for missing `complete()`
- `make check PYTHON=/tmp/valleybot-venv-20260625/bin/python`
- 74 dependency-free contracts
- 43 Bottle/WebTest and bot runtime tests
- 5 hostile web-chat mutations
- `python -m pip check`

No live Messenger webhook or provider request was sent. Hosted Python 3.10/3.12/3.14 and CodeQL checks remain required before merge.
