### PR TITLE
Preserve in-flight Slack replay claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@
 - `MESSENGER_VERIFY_TOKEN` configures Messenger webhook verification; missing
   values fail closed and never fall back to `MESSENGER_TOKEN`.
 - `REQUEST_TIMEOUT` optionally overrides outbound Messenger request timeout seconds; invalid, non-finite, or non-positive values fall back to `5.0`.
+- In-flight Slack signatures are never capacity-evicted; only completed claims
+  enter the bounded replay cache, and failures release claims for retry.
 - In-flight Messenger message-ID claims are never capacity-evicted; only
   completed claims enter the bounded replay cache.
 - Preserve punctuation and non-space whitespace token boundaries in the final

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,10 @@ second time.
   startup and override cases passed.
 - Python 3.14 `make check` — 75 dependency-free contracts, 43 Bottle/bot
   runtime tests, five existing web-chat mutations, syntax, and corpus checks passed.
+- Hosted runs `28214128990` and `28214129936` — Python 3.10/3.12/3.14 and
+  Actions/Python CodeQL passed on the reviewed implementation head.
+- Codex review — attempted as requested but blocked by OpenAI API HTTP 401;
+  manual exact-head concurrency, security, and regression review found no findings.
 
 ### Bugs / findings
 
@@ -43,11 +47,13 @@ second time.
 
 ### Blockers
 
-- No live Slack webhook was sent; hosted matrices remain before merge.
+- No live Slack webhook was sent; multi-worker global replay suppression still
+  requires a shared store.
 
 ### Next action
 
-- Run `make check`, review the exact head, and merge only after hosted checks pass.
+- Merge the final hosted-green head, then load-test concurrent valid retries
+  near replay-cache capacity.
 
 ## 2026-06-25T21:16:14Z — P1 concurrency/correctness — cycle: Messenger in-flight replay claims
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,54 @@
 # Changes
 
+## 2026-06-26T02:53:26Z — P1 concurrency/correctness — cycle: Slack in-flight replay claims
+
+### Summary
+
+The bounded Slack replay cache could evict a signature while its bot response
+was still running, allowing a concurrent exact retry to execute the command a
+second time.
+
+### Work completed
+
+- Split process-local Slack replay state into in-flight and completed claims.
+- Added explicit success completion to both Bottle and standalone handlers.
+- Preserved duplicate acknowledgement and failure-release retry recovery.
+- Added completed-cache eviction, capacity-pressure, source-order, and six
+  hostile-mutation regressions.
+
+### Threads
+
+- None; the focused repository change was implemented directly.
+
+### Files changed
+
+- `slack_replay.py`, `app.py`, and `slack.py` — explicit replay ownership.
+- `scripts/check_valleybot_contracts.py` and
+  `scripts/test_slack_replay_mutations.py` — behavior and mutation proof.
+- Security, vision, agent, README, plan, and Make verification documentation.
+
+### Validation
+
+- Dependency-free contracts — 75 tests passed after RED failed on the missing
+  `complete()` transition.
+- Slack replay mutation contract — six hostile mutations rejected.
+- Make authority matrix — all 40 target/authority cases and documented hostile
+  startup and override cases passed.
+- Python 3.14 `make check` — 75 dependency-free contracts, 43 Bottle/bot
+  runtime tests, five existing web-chat mutations, syntax, and corpus checks passed.
+
+### Bugs / findings
+
+- P1: completed-cache capacity previously applied to pending Slack claims.
+
+### Blockers
+
+- No live Slack webhook was sent; hosted matrices remain before merge.
+
+### Next action
+
+- Run `make check`, review the exact head, and merge only after hosted checks pass.
+
 ## 2026-06-25T21:16:14Z — P1 concurrency/correctness — cycle: Messenger in-flight replay claims
 
 - Threads: inspected the explicit Apache 2.0 license, default branch, open pull

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ PYTHON_FILES := \
 	slack.py \
 	scripts/check_nltk_data.py \
 	scripts/check_valleybot_contracts.py \
+	scripts/test_slack_replay_mutations.py \
 	scripts/test_web_chat_length_contract.py
 
 build check clean lint prepare-corpora root-test test verify:: $$(if $$(filter file,$$(origin MAKEFILE_LIST)),,$$(error MAKEFILE_LIST must not be overridden))
@@ -99,6 +100,7 @@ prepare-corpora::
 
 test:: prepare-corpora
 	REPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/run-python.sh' '$(REPOSITORY_ROOT_LITERAL)/scripts/check_valleybot_contracts.py'
+	REPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/run-python.sh' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_slack_replay_mutations.py'
 	REPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/run-python.sh' '$(REPOSITORY_ROOT_LITERAL)/scripts/test_web_chat_length_contract.py'
 	cd '$(REPOSITORY_ROOT_LITERAL)' && /usr/bin/env SLACK_SIGNING_SECRET=test-slack-signing-secret MESSENGER_TOKEN=test-page-token MESSENGER_VERIFY_TOKEN=test-verify-token REPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/run-python.sh' '$(REPOSITORY_ROOT_LITERAL)/bot_tests.py'
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ When the required SDK or runtime is unavailable, use static checks and source re
   entry points reject unsigned, stale, future, or tampered request bodies
   before bot execution and cap raw bodies at 1 MiB; the deprecated payload
   verification token is not used.
-- Verified commands use bounded process-local Slack signature claims so an
-  exact retry does not call the bot twice; separate processes still require a
-  shared replay store for global suppression.
+- Verified commands keep in-flight Slack signature claims outside the bounded
+  completed replay cache, so capacity pressure cannot re-enter a bot call that
+  is still running. Separate processes still require a shared replay store for
+  global suppression.
 - `MESSENGER_TOKEN` configures Facebook Messenger API replies.
 - `MESSENGER_VERIFY_TOKEN` configures Messenger webhook verification. Missing
   values fail closed and never fall back to `MESSENGER_TOKEN`.
@@ -210,6 +211,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   failure handling and replay-claim recovery.
 - See `docs/plans/2026-06-17-slack-request-replay-guard.md` for bounded
   process-local Slack signature claims and failure recovery.
+- See `docs/plans/2026-06-25-slack-inflight-replay.md` for in-flight claim
+  ownership and completed-only capacity eviction.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,10 +77,12 @@ five-minute timestamp window for both entry points. Unsigned, stale, future,
 tampered, or larger-than-1-MiB Slack commands must fail before bot execution;
 the deprecated payload verification token is not an authentication fallback.
 Authenticated command text must still be textual and nonblank.
-Bounded process-local Slack signature claims suppress exact retries before a
-second bot call and are released after processing failures. Separate workers,
-restarts, and evicted entries require a shared persistent replay store for
-global suppression.
+Process-local Slack replay state keeps in-flight signatures protected until bot
+generation succeeds or fails. Only completed signatures enter the bounded
+oldest-first cache, so capacity pressure cannot evict a still-running claim;
+failures release claims for retry recovery. Separate workers, restarts, and
+evicted completed entries require a shared persistent replay store for global
+suppression.
 
 The public `/bot` route rejects chat input over 1,000 trimmed Unicode
 characters before TextBlob/NLTK processing. This limits per-request parser and

--- a/VISION.md
+++ b/VISION.md
@@ -16,7 +16,7 @@ Priority:
 
 - Keep the service on supported Python 3 and current audited dependencies
 - Require Slack signing secret verification before command execution
-- Suppress repeated Slack signatures with bounded process-local state
+- Keep in-flight Slack signatures protected and bound only completed replay state
 - Require authenticated Messenger POST payloads before event parsing
 - Bound unauthenticated Messenger request bodies before signature verification
 - Run the complete runtime suite across supported Python versions in CI

--- a/app.py
+++ b/app.py
@@ -91,7 +91,9 @@ def slack_handler():
     if not recent_slack_signatures.claim(slack_signature):
         return "ok"
     try:
-        return bot.respond(command_text)
+        result = bot.respond(command_text)
+        recent_slack_signatures.complete(slack_signature)
+        return result
     except Exception:
         recent_slack_signatures.release(slack_signature)
         raise

--- a/docs/plans/2026-06-25-slack-inflight-replay-design.md
+++ b/docs/plans/2026-06-25-slack-inflight-replay-design.md
@@ -1,0 +1,70 @@
+# Slack In-Flight Replay Claims Design
+
+Status: Approved
+
+## Current State
+
+Both Slack entry points verify the signed raw request, normalize command text,
+claim the signature, and release the claim if bot generation raises. The
+process-local replay cache stores pending and successful claims in one bounded
+`OrderedDict`.
+
+Capacity eviction can therefore remove the oldest signature while its bot call
+is still running. A concurrent retry of that exact signed request can claim the
+signature again and execute the command twice.
+
+## External Evidence
+
+- Slack requires signed-request verification using the raw request body,
+  timestamp, and `X-Slack-Signature` header:
+  <https://docs.slack.dev/authentication/verifying-requests-from-slack>
+- Slack documents a three-second acknowledgement boundary and retry behavior
+  for delayed event delivery, making overlapping deliveries a supported
+  operational condition:
+  <https://docs.slack.dev/apis/events-api#retries>
+
+The retry documentation is for the Events API rather than this repository's
+legacy slash-command adapter, so the concurrency conclusion is an inference:
+network retries and concurrent duplicate delivery must not re-enter bot work
+while the original signed request remains pending.
+
+## Constraints
+
+- Preserve the current process-local, bounded replay scope.
+- Preserve duplicate acknowledgement as `ok`.
+- Preserve retry recovery when bot generation raises.
+- Keep Bottle and standalone event adapters behaviorally identical.
+- Avoid holding a lock while generating a bot response.
+
+## Considered Approaches
+
+### Recommended: Separate in-flight and completed signatures
+
+Keep pending signatures in an unbounded-by-capacity set and successful
+signatures in the existing bounded `OrderedDict`. `claim()` rejects either
+state, `complete()` moves a pending signature to completed state, and
+`release()` removes both states after failure.
+
+This matches the Messenger replay state machine already maintained in
+`app.py`, preserves concurrency, and bounds only entries safe to evict.
+
+### Rejected: Make the single cache unbounded
+
+This prevents pending eviction but permits permanent process memory growth
+from successful requests.
+
+### Rejected: Hold the replay lock through bot generation
+
+This prevents eviction races but serializes unrelated Slack commands and makes
+slow NLP work a global request bottleneck.
+
+## Validation
+
+- RED: calling the required `complete()` transition must fail before the
+  implementation exists.
+- Prove capacity pressure never makes an in-flight signature reclaimable.
+- Prove completed signatures remain bounded and oldest-first evicted.
+- Prove both handlers complete only after successful bot generation and release
+  after exceptions.
+- Run dependency-free contracts, runtime tests, hostile mutations, and
+  `make check` before review.

--- a/docs/plans/2026-06-25-slack-inflight-replay.md
+++ b/docs/plans/2026-06-25-slack-inflight-replay.md
@@ -64,5 +64,10 @@ Status: Completed
   mutations were rejected.
 - Python 3.14 `make check` passed the 43 Bottle/bot runtime tests, syntax and
   corpus checks, and all 40 Make target/authority cases.
-- No live Slack webhook was sent; hosted Python 3.10/3.12/3.14 and CodeQL
-  verification remains required before merge.
+- Hosted runs `28214128990` and `28214129936` passed Python 3.10, Python 3.12,
+  Python 3.14, Actions CodeQL, and Python CodeQL on commit
+  `8874e42b319d92f22ff930a8f4d48afbb807c697`.
+- `codex review --base origin/master` was attempted but could not authenticate
+  to the OpenAI API (HTTP 401); manual exact-head review found no findings.
+- No live Slack webhook was sent; multi-worker global replay suppression still
+  requires a shared store.

--- a/docs/plans/2026-06-25-slack-inflight-replay.md
+++ b/docs/plans/2026-06-25-slack-inflight-replay.md
@@ -1,0 +1,68 @@
+# Slack In-Flight Replay Claims Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent replay-cache capacity from evicting a Slack signature while its bot response is still being generated.
+
+**Architecture:** Split replay state into in-flight and completed signatures. Keep pending claims protected until each handler explicitly completes or releases them, while retaining bounded oldest-first eviction for successful claims.
+
+**Tech Stack:** Python 3.10-3.14, Bottle, stdlib threading and collections, dependency-free contract tests, GNU Make.
+
+---
+
+Status: Completed
+
+### Task 1: Prove the replay race
+
+**Files:**
+- Modify: `scripts/check_valleybot_contracts.py`
+
+1. Add a test that calls `complete()` and verifies completed claims are bounded.
+2. Add a capacity-pressure test proving an in-flight signature cannot be reclaimed.
+3. Register both tests in the dependency-free test list.
+4. Run `scripts/run-python.sh scripts/check_valleybot_contracts.py` and verify RED fails because `complete()` is missing.
+
+### Task 2: Implement explicit completion
+
+**Files:**
+- Modify: `slack_replay.py`
+- Modify: `app.py`
+- Modify: `slack.py`
+
+1. Store pending signatures in `_inflight` and successes in `_completed`.
+2. Add `complete(signature)` to move a claim after successful bot generation.
+3. Keep `release(signature)` available for retry recovery after failure.
+4. Update both handlers to complete only after `bot.respond()` succeeds.
+5. Run the focused dependency-free suite and verify GREEN.
+
+### Task 3: Lock the contract and documentation
+
+**Files:**
+- Modify: `scripts/check_valleybot_contracts.py`
+- Modify: `README.md`
+- Modify: `SECURITY.md`
+- Modify: `VISION.md`
+- Modify: `AGENTS.md`
+- Modify: `CHANGES.md`
+- Modify: `docs/plans/2026-06-25-slack-inflight-replay.md`
+
+1. Require separate state and claim/respond/complete/release ordering.
+2. Add isolated hostile mutations for completion and capacity safety.
+3. Document process-local replay guarantees and multi-worker limits.
+4. Mark this plan completed with exact verification evidence.
+5. Run `make check` and commit the focused change.
+
+## Verification Evidence
+
+- RED failed with `AttributeError` because `RecentSlackSignatures.complete()`
+  did not exist.
+- GREEN passed 75 dependency-free contracts, including completed-cache
+  eviction and in-flight capacity-pressure behavior.
+- Both Bottle and standalone Slack handlers retain claim, response,
+  completion, and failure-release ordering.
+- Six isolated hostile Slack replay mutations and five existing web-chat
+  mutations were rejected.
+- Python 3.14 `make check` passed the 43 Bottle/bot runtime tests, syntax and
+  corpus checks, and all 40 Make target/authority cases.
+- No live Slack webhook was sent; hosted Python 3.10/3.12/3.14 and CodeQL
+  verification remains required before merge.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -101,6 +101,9 @@ SLACK_SIGNING_SECRET_PLAN_PATH = (
 SLACK_REPLAY_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-17-slack-request-replay-guard.md"
 )
+SLACK_INFLIGHT_REPLAY_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-25-slack-inflight-replay.md"
+)
 WEB_CHAT_LENGTH_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-17-web-chat-input-length.md"
 )
@@ -383,6 +386,9 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_DEBUG_FIELD_PLAN_PATH, "Messenger debug field handling")
     assert_completed_plan(SLACK_SIGNING_SECRET_PLAN_PATH, "Slack signing secret")
     assert_completed_plan(SLACK_REPLAY_PLAN_PATH, "Slack request replay guard")
+    assert_completed_plan(
+        SLACK_INFLIGHT_REPLAY_PLAN_PATH, "Slack in-flight replay claims"
+    )
     assert_completed_plan(WEB_CHAT_LENGTH_PLAN_PATH, "web chat input length")
     assert_completed_plan(NLTK_RESOURCE_GUARD_PLAN_PATH, "NLTK resource path guard")
     assert_completed_plan(MAKE_AUTHORITY_PLAN_PATH, "Make authority isolation")
@@ -1958,15 +1964,32 @@ def test_standalone_slack_handler_releases_replay_claim_after_failure():
     )
 
 
-def test_recent_slack_signatures_evicts_oldest_claim():
+def test_recent_slack_signatures_evicts_oldest_completed_claim():
     from slack_replay import RecentSlackSignatures
 
     recent = RecentSlackSignatures(2)
     assert_true(recent.claim("first"), "first Slack signature claim")
+    recent.complete("first")
     assert_true(recent.claim("second"), "second Slack signature claim")
+    recent.complete("second")
     assert_true(not recent.claim("first"), "duplicate Slack signature claim")
     assert_true(recent.claim("third"), "third Slack signature claim")
+    recent.complete("third")
     assert_true(recent.claim("first"), "evicted Slack signature can be reclaimed")
+
+
+def test_recent_slack_signatures_never_evicts_inflight_claims():
+    from slack_replay import RecentSlackSignatures
+
+    recent = RecentSlackSignatures(2)
+    assert_true(recent.claim("inflight"), "in-flight Slack signature claim")
+    for signature in ("completed-1", "completed-2", "completed-3"):
+        assert_true(recent.claim(signature), "completed Slack signature claim")
+        recent.complete(signature)
+    assert_true(
+        not recent.claim("inflight"),
+        "in-flight Slack signature must remain protected under capacity pressure",
+    )
 
 
 def test_slack_replay_source_contracts():
@@ -1977,9 +2000,15 @@ def test_slack_replay_source_contracts():
     for contract in (
             "MAX_RECENT_SLACK_SIGNATURES = 1024",
             "class RecentSlackSignatures(object):",
+            "self._inflight = set()",
+            "self._completed = OrderedDict()",
             "with self._lock:",
-            "while len(self._signatures) > self.max_entries:",
-            "self._signatures.popitem(last=False)"):
+            "if signature in self._inflight or signature in self._completed:",
+            "self._inflight.add(signature)",
+            "def complete(self, signature):",
+            "self._inflight.discard(signature)",
+            "while len(self._completed) > self.max_entries:",
+            "self._completed.popitem(last=False)"):
         assert_true(contract in replay_source, "missing Slack replay contract {0}".format(contract))
 
     for source, label in ((app_source, "Bottle"), (adapter_source, "event")):
@@ -1987,10 +2016,16 @@ def test_slack_replay_source_contracts():
         text_position = source.index("command_text = clean_text_value", verify_position)
         claim_position = source.index("recent_slack_signatures.claim(slack_signature)", text_position)
         bot_position = source.index("bot.respond(command_text)", claim_position)
-        release_position = source.index("recent_slack_signatures.release(slack_signature)", bot_position)
+        complete_position = source.index(
+            "recent_slack_signatures.complete(slack_signature)", bot_position
+        )
+        release_position = source.index(
+            "recent_slack_signatures.release(slack_signature)", complete_position
+        )
         assert_true(
-            verify_position < text_position < claim_position < bot_position < release_position,
-            "{0} Slack replay claim and release ordering".format(label),
+            verify_position < text_position < claim_position < bot_position
+            < complete_position < release_position,
+            "{0} Slack replay claim, completion, and release ordering".format(label),
         )
         assert_true(
             'return "ok"' in source[claim_position:bot_position],
@@ -2005,21 +2040,35 @@ def test_slack_replay_source_contracts():
             "test_slack_command_releases_replay_claim_after_failure",
             "test_standalone_slack_handler_suppresses_replayed_signature",
             "test_standalone_slack_handler_releases_replay_claim_after_failure",
-            "test_recent_slack_signatures_evicts_oldest_claim",
+            "test_recent_slack_signatures_evicts_oldest_completed_claim",
+            "test_recent_slack_signatures_never_evicts_inflight_claims",
             "test_slack_replay_source_contracts"):
         assert_true(test_name in registered, "Slack replay test must remain registered: {0}".format(test_name))
 
     docs = {
-        "README.md": "bounded process-local Slack signature claims",
-        "SECURITY.md": "Bounded process-local Slack signature claims",
-        "VISION.md": "Suppress repeated Slack signatures with bounded process-local state",
-        "CHANGES.md": "Suppressed repeated Slack signatures in each running process",
+        "README.md": "in-flight Slack signature claims outside the bounded",
+        "SECURITY.md": "Only completed signatures enter the bounded",
+        "VISION.md": "Keep in-flight Slack signatures protected",
+        "AGENTS.md": "In-flight Slack signatures are never capacity-evicted",
+        "CHANGES.md": "Slack in-flight replay claims",
     }
     for relative_path, phrase in docs.items():
         assert_true(
             phrase in (ROOT / relative_path).read_text(encoding="utf-8"),
             "{0} must document Slack replay suppression".format(relative_path),
         )
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    mutation_source = (
+        ROOT / "scripts" / "test_slack_replay_mutations.py"
+    ).read_text(encoding="utf-8")
+    assert_true(
+        "scripts/test_slack_replay_mutations.py" in makefile,
+        "Make test must run Slack replay mutations",
+    )
+    assert_true(
+        "Slack replay contract passed (6 mutations rejected)" in mutation_source,
+        "Slack replay mutation proof must remain explicit",
+    )
 
 
 def test_standalone_slack_handler_rejects_blank_text():
@@ -2132,7 +2181,8 @@ def main():
         test_standalone_slack_handler_accepts_valid_signature,
         test_standalone_slack_handler_suppresses_replayed_signature,
         test_standalone_slack_handler_releases_replay_claim_after_failure,
-        test_recent_slack_signatures_evicts_oldest_claim,
+        test_recent_slack_signatures_evicts_oldest_completed_claim,
+        test_recent_slack_signatures_never_evicts_inflight_claims,
         test_standalone_slack_handler_rejects_blank_text,
         test_standalone_slack_handler_rejects_missing_text,
         test_standalone_slack_handler_accepts_signed_base64_body,

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -35,7 +35,7 @@ printf '%s|%s|%s\n' "$PWD" "$0" "$*" >> "$VALLEYBOT_COMMAND_LOG"
 EOF
 chmod +x "$FAKE_PYTHON"
 
-for script in test-makefile-root.sh check_valleybot_contracts.py test_web_chat_length_contract.py prepare_nltk_data.sh; do
+for script in test-makefile-root.sh check_valleybot_contracts.py test_slack_replay_mutations.py test_web_chat_length_contract.py prepare_nltk_data.sh; do
     cp "$FAKE_PYTHON" "$CHECKOUT/scripts/$script"
 done
 cp "$ROOT_DIR/scripts/run-python.sh" "$CHECKOUT/scripts/run-python.sh"

--- a/scripts/test_slack_replay_mutations.py
+++ b/scripts/test_slack_replay_mutations.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Mutation-sensitive contracts for Slack replay claim ownership."""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def validate(replay_source, app_source, adapter_source):
+    for contract in (
+            "self._inflight = set()",
+            "self._completed = OrderedDict()",
+            "if signature in self._inflight or signature in self._completed:",
+            "self._inflight.add(signature)",
+            "def complete(self, signature):",
+            "while len(self._completed) > self.max_entries:",
+            "self._completed.popitem(last=False)"):
+        require(contract in replay_source, "missing replay state contract")
+
+    complete_start = replay_source.index("def complete(self, signature):")
+    release_start = replay_source.index("def release(self, signature):", complete_start)
+    require(
+        "self._inflight.discard(signature)"
+        in replay_source[complete_start:release_start],
+        "completion must retire the in-flight claim",
+    )
+
+    for source in (app_source, adapter_source):
+        claim = source.index("recent_slack_signatures.claim(slack_signature)")
+        respond = source.index("bot.respond(command_text)", claim)
+        complete = source.index(
+            "recent_slack_signatures.complete(slack_signature)", respond
+        )
+        release = source.index(
+            "recent_slack_signatures.release(slack_signature)", complete
+        )
+        require(claim < respond < complete < release, "invalid handler ownership order")
+
+
+def replace_once(source, old, new):
+    require(source.count(old) == 1, "mutation target must appear exactly once")
+    return source.replace(old, new, 1)
+
+
+def main():
+    replay_source = (ROOT / "slack_replay.py").read_text(encoding="utf-8")
+    app_source = (ROOT / "app.py").read_text(encoding="utf-8")
+    adapter_source = (ROOT / "slack.py").read_text(encoding="utf-8")
+    validate(replay_source, app_source, adapter_source)
+
+    mutations = {
+        "in-flight state removed": (
+            replace_once(replay_source, "self._inflight = set()", "self._inflight = {}"),
+            app_source,
+            adapter_source,
+        ),
+        "claim ignores in-flight": (
+            replace_once(
+                replay_source,
+                "if signature in self._inflight or signature in self._completed:",
+                "if signature in self._completed:",
+            ),
+            app_source,
+            adapter_source,
+        ),
+        "completion keeps in-flight claim": (
+            replace_once(
+                replay_source,
+                "def complete(self, signature):\n"
+                "        with self._lock:\n"
+                "            self._inflight.discard(signature)",
+                "def complete(self, signature):\n"
+                "        with self._lock:\n"
+                "            self._inflight.add(signature)",
+            ),
+            app_source,
+            adapter_source,
+        ),
+        "completed bound removed": (
+            replace_once(
+                replay_source,
+                "while len(self._completed) > self.max_entries:",
+                "while False:",
+            ),
+            app_source,
+            adapter_source,
+        ),
+        "Bottle completion removed": (
+            replay_source,
+            replace_once(
+                app_source,
+                "recent_slack_signatures.complete(slack_signature)",
+                "recent_slack_signatures.release(slack_signature)",
+            ),
+            adapter_source,
+        ),
+        "event completion removed": (
+            replay_source,
+            app_source,
+            replace_once(
+                adapter_source,
+                "recent_slack_signatures.complete(slack_signature)",
+                "recent_slack_signatures.release(slack_signature)",
+            ),
+        ),
+    }
+
+    for label, sources in mutations.items():
+        try:
+            validate(*sources)
+        except (AssertionError, ValueError):
+            continue
+        raise AssertionError("{0} mutation unexpectedly passed".format(label))
+
+    print("Slack replay contract passed (6 mutations rejected)")
+
+
+if __name__ == "__main__":
+    main()

--- a/slack.py
+++ b/slack.py
@@ -61,7 +61,9 @@ def slack_handler(event, now=None):
     if not recent_slack_signatures.claim(slack_signature):
         return "ok"
     try:
-        return bot.respond(command_text)
+        result = bot.respond(command_text)
+        recent_slack_signatures.complete(slack_signature)
+        return result
     except Exception:
         recent_slack_signatures.release(slack_signature)
         raise

--- a/slack_replay.py
+++ b/slack_replay.py
@@ -8,18 +8,25 @@ MAX_RECENT_SLACK_SIGNATURES = 1024
 class RecentSlackSignatures(object):
     def __init__(self, max_entries=MAX_RECENT_SLACK_SIGNATURES):
         self.max_entries = max_entries
-        self._signatures = OrderedDict()
+        self._inflight = set()
+        self._completed = OrderedDict()
         self._lock = threading.Lock()
 
     def claim(self, signature):
         with self._lock:
-            if signature in self._signatures:
+            if signature in self._inflight or signature in self._completed:
                 return False
-            self._signatures[signature] = None
-            while len(self._signatures) > self.max_entries:
-                self._signatures.popitem(last=False)
+            self._inflight.add(signature)
             return True
+
+    def complete(self, signature):
+        with self._lock:
+            self._inflight.discard(signature)
+            self._completed[signature] = None
+            while len(self._completed) > self.max_entries:
+                self._completed.popitem(last=False)
 
     def release(self, signature):
         with self._lock:
-            self._signatures.pop(signature, None)
+            self._inflight.discard(signature)
+            self._completed.pop(signature, None)


### PR DESCRIPTION
## Summary
- keep pending Slack signatures outside the bounded completed replay cache
- complete claims only after successful bot generation in both entry points
- preserve duplicate acknowledgement and failure-release retry recovery
- add capacity-pressure, completed-eviction, source-order, and mutation coverage

## Validation
- `make check PYTHON=/tmp/valleybot-venv/bin/python` on Python 3.14.6
- 75 dependency-free contracts
- 43 Bottle/bot runtime tests
- 6 Slack replay mutations and 5 web-chat mutations rejected
- 40 Make target/authority cases plus hostile startup/override cases

## Notes
- no live Slack webhook was sent
- replay state remains process-local; multi-worker global suppression still requires shared storage
