### PR TITLE
docs: clarify Python and NLTK setup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,42 @@
 # Changes
 
+## 2026-06-26T06:20:42Z — P2 documentation/reproducibility — cycle: Python and NLTK setup
+
+### Summary
+
+Documented same-interpreter Python and NLTK setup so virtual-environment
+dependency installs cannot silently diverge from Make's `/usr/bin/python3`
+default.
+
+### Work completed
+
+- Made Python 3.14 the deployment-equivalent local recommendation while
+  retaining the tested Python 3.10 and 3.12 support boundary.
+- Added virtual-environment creation, activation, dependency installation,
+  project-local TextBlob corpus preparation, and full verification commands.
+- Explained the required absolute `PYTHON` Make override, downloaded `lite`
+  resources, network boundary, and missing-resource recovery path.
+- Closed the completed Python and NLTK/TextBlob documentation roadmap item.
+- Added a dependency-free contract and completed maintenance plan.
+
+### Threads
+
+- None; this focused documentation contract was implemented directly.
+
+### Files changed
+
+- `README.md`, `VISION.md`, and `CHANGES.md` — setup and roadmap guidance.
+- `scripts/check_valleybot_contracts.py` — frozen documentation contract.
+- `docs/plans/2026-06-25-python-nltk-setup.md` — completed plan and evidence.
+
+### Validation
+
+- Focused setup documentation contract passed after failing on the missing
+  plan and setup guidance.
+- The documented Python 3.14 `.venv` path passed full `make check`: 76
+  dependency-free contracts, 43 runtime tests, 11 hostile mutations, corpus
+  verification, and the 40-case Make authority matrix.
+
 ## 2026-06-26T02:53:26Z — P1 concurrency/correctness — cycle: Slack in-flight replay claims
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -38,14 +38,31 @@ Additional scan context:
 
 ### Setup
 
+Use Python 3.14 for the deployment-equivalent environment. Python 3.10 and
+3.12 remain supported because the complete gate runs on all three versions.
+Keep dependencies and corpus downloads tied to the same activated interpreter:
+
 ```bash
 git clone https://github.com/garethpaul/valleybot.git
 cd valleybot
+python3.14 -m venv .venv
+source .venv/bin/activate
 python -m pip install -r requirements.txt
-make prepare-corpora
+make prepare-corpora PYTHON="$(command -v python)"
+make check PYTHON="$(command -v python)"
 ```
 
-The setup commands above are derived from repository files. Legacy mobile, Python, or JavaScript samples may require older SDKs or package versions than a modern workstation uses by default.
+`make prepare-corpora` downloads the TextBlob `lite` corpora and verifies the
+Brown corpus, Punkt tokenizer tables, WordNet, and English perceptron tagger in
+the project-local `nltk_data` directory. The command requires network access
+when those resources are absent. Keep the `PYTHON` override on Make commands:
+without it, the Makefile intentionally defaults to `/usr/bin/python3`, which
+may differ from the interpreter where dependencies were installed.
+
+If TextBlob reports a missing NLTK resource, reactivate `.venv` and rerun
+`make prepare-corpora PYTHON="$(command -v python)"`. Do not fix the error by
+pointing `NLTK_DATA` at a user-global directory; verification requires the
+reviewed project-local corpus directory.
 
 ## Running or Using the Project
 
@@ -96,7 +113,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   values remain neutralized without expansion.
 - `make prepare-corpora` installs and verifies the current TextBlob tokenizer
   and tagger data in the existing project-local `nltk_data` directory. Heroku
-  runs the same step through `bin/post_compile`.
+  runs the same step through `bin/post_compile`; local virtual environments
+  must pass their absolute interpreter through `PYTHON`.
 - `python scripts/check_valleybot_contracts.py` runs just the webhook and token-handling contracts.
 - GitHub Actions installs dependencies and runs the complete gate on Python
   3.10, 3.12, and 3.14 on Ubuntu 24.04 with read-only permissions, immutable

--- a/VISION.md
+++ b/VISION.md
@@ -56,7 +56,6 @@ Priority:
 
 Next priorities:
 
-- Document Python version and NLTK/TextBlob setup
 - Separate deployment packaging from bot behavior changes
 
 Contribution rules:

--- a/docs/plans/2026-06-25-python-nltk-setup.md
+++ b/docs/plans/2026-06-25-python-nltk-setup.md
@@ -1,0 +1,45 @@
+# Python And NLTK Setup
+
+status: completed
+
+## Context
+
+The README installed dependencies with the caller's `python` command but then
+ran Make without a `PYTHON` override. Make intentionally defaults to
+`/usr/bin/python3`, so an activated virtual environment could receive the
+packages while corpus preparation and verification used a different
+interpreter.
+
+## Requirements
+
+- Recommend the deployment-equivalent Python 3.14 line while preserving the
+  tested Python 3.10 and 3.12 support boundary.
+- Create and activate a repository-local virtual environment.
+- Pass the activated interpreter's absolute path to corpus preparation and
+  verification.
+- Explain which TextBlob/NLTK resources are installed, where they live, and
+  when network access is required.
+- Provide a recovery path for missing-resource errors without relying on
+  user-global NLTK state.
+- Remove the completed setup item from the roadmap.
+
+## Work Completed
+
+- Added a same-interpreter setup sequence from clone through `make check`.
+- Documented the TextBlob `lite` corpus contents and project-local
+  `nltk_data` verification boundary.
+- Added missing-resource troubleshooting that preserves the reviewed local
+  data path.
+- Added a dependency-free documentation contract and changelog record.
+- Removed the completed Python and NLTK/TextBlob setup priority from VISION.
+
+## Verification Completed
+
+- Reproduced the missing documentation as a failing dependency-free contract.
+- Ran the focused setup documentation contract.
+- Created the documented Python 3.14 `.venv`, installed the pinned
+  requirements, and ran `make check` with its absolute interpreter path.
+- Passed 76 dependency-free contracts, 43 Bottle/bot runtime tests, six Slack
+  replay mutations, five web-chat length mutations, corpus verification, and
+  the 40-case Make authority matrix.
+- Confirmed `git diff --check` passes.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -113,6 +113,9 @@ NLTK_RESOURCE_GUARD_PLAN_PATH = (
 MAKE_AUTHORITY_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-21-make-authority-isolation.md"
 )
+PYTHON_NLTK_SETUP_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-25-python-nltk-setup.md"
+)
 
 
 class FakeBottle:
@@ -392,6 +395,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(WEB_CHAT_LENGTH_PLAN_PATH, "web chat input length")
     assert_completed_plan(NLTK_RESOURCE_GUARD_PLAN_PATH, "NLTK resource path guard")
     assert_completed_plan(MAKE_AUTHORITY_PLAN_PATH, "Make authority isolation")
+    assert_completed_plan(PYTHON_NLTK_SETUP_PLAN_PATH, "Python and NLTK setup")
     registered = registered_main_tests(
         (ROOT / "scripts" / "check_valleybot_contracts.py").read_text(encoding="utf-8")
     )
@@ -702,6 +706,29 @@ def test_prepare_corpora_uses_project_local_nltk_data_contract():
         "and tagger data in the existing project-local `nltk_data` directory"
         in normalized_readme,
         "README must truthfully describe make prepare-corpora resource path",
+    )
+
+
+def test_python_nltk_setup_documentation_contract():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    vision = (ROOT / "VISION.md").read_text(encoding="utf-8")
+    changes = (ROOT / "CHANGES.md").read_text(encoding="utf-8")
+    for contract in (
+            "python3.14 -m venv .venv",
+            "source .venv/bin/activate",
+            'make prepare-corpora PYTHON="$(command -v python)"',
+            'make check PYTHON="$(command -v python)"',
+            "downloads the TextBlob `lite` corpora",
+            "project-local `nltk_data` directory",
+            "If TextBlob reports a missing NLTK resource"):
+        assert_true(contract in readme, "README must retain setup contract {0}".format(contract))
+    assert_true(
+        "Document Python version and NLTK/TextBlob setup" not in vision,
+        "VISION must remove the completed Python and NLTK setup priority",
+    )
+    assert_true(
+        "same-interpreter Python and NLTK setup" in changes,
+        "CHANGES must record the Python and NLTK setup contract",
     )
 
 
@@ -2117,6 +2144,7 @@ def main():
         test_nltk_resource_path_guard_contracts,
         test_shell_entrypoints_use_portable_cdpath_reset,
         test_prepare_corpora_uses_project_local_nltk_data_contract,
+        test_python_nltk_setup_documentation_contract,
         test_messenger_post_rejects_oversized_declared_body,
         test_messenger_post_rejects_oversized_streamed_body,
         test_messenger_post_rejects_invalid_signature,


### PR DESCRIPTION
## Summary
- document a Python 3.14 virtual-environment setup while retaining the tested 3.10/3.12 boundary
- pass the activated interpreter explicitly to Make so installs, corpus preparation, and tests cannot diverge
- explain TextBlob `lite` corpus contents, project-local `nltk_data`, network requirements, and recovery
- close the completed roadmap item with a dependency-free contract and maintenance plan

## Verification
- focused setup contract (RED on missing plan, then green)
- `make check PYTHON="$PWD/.venv/bin/python"`
  - 76 dependency-free contracts
  - 43 Bottle/bot runtime tests
  - 6 Slack replay mutations
  - 5 web-chat length mutations
  - 40-case Make authority matrix
- `git diff --check`
