### PR TITLE
docs: define deployment packaging boundary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,42 @@
 # Changes
 
+## 2026-06-26T06:23:47Z — P2 documentation/reviewability — cycle: deployment packaging boundary
+
+### Summary
+
+Separated deployment packaging review from bot behavior changes with an
+explicit file-ownership, configuration, validation, and rollback guide.
+
+### Work completed
+
+- Defined `.python-version`, `requirements.txt`, `Procfile`, `app.json`, and
+  `bin/post_compile` as the packaging-owned surface.
+- Kept routes, authentication, moderation, responses, request limits, retries,
+  and provider API behavior outside packaging-only PRs.
+- Documented provider-owned secrets, runtime `PORT`, project-local corpus
+  preparation, offline validation, hosted matrix evidence, and rollback scope.
+- Linked the guide from README and closed the final explicit roadmap item.
+- Added a dependency-free deployment documentation contract and completed plan.
+
+### Threads
+
+- None; this focused documentation boundary was implemented directly.
+
+### Files changed
+
+- `DEPLOYMENT.md` — packaging ownership and validation guide.
+- `README.md`, `VISION.md`, and `CHANGES.md` — navigation and roadmap state.
+- `scripts/check_valleybot_contracts.py` — frozen documentation contract.
+- `docs/plans/2026-06-25-deployment-packaging-boundary.md` — completed plan.
+
+### Validation
+
+- Focused deployment documentation contract passed after failing on the
+  missing guide and plan.
+- Python 3.14 `make check` passed 77 dependency-free contracts, 43 runtime
+  tests, 11 hostile mutations, corpus verification, and the 40-case Make
+  authority matrix; JSON and shell syntax checks also passed.
+
 ## 2026-06-26T06:20:42Z — P2 documentation/reproducibility — cycle: Python and NLTK setup
 
 ### Summary

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,55 @@
+# Deployment Packaging Boundary
+
+Deployment packaging tells a provider how to install and start Valleybot. It
+must stay reviewable separately from chatbot responses, routes, authentication,
+moderation, and webhook behavior.
+
+## Packaging-Owned Files
+
+Packaging-only changes own this narrow surface:
+
+- `.python-version` selects the deployment Python line.
+- `requirements.txt` pins installed Python packages.
+- `Procfile` starts the Bottle application with the provider-supplied `PORT`.
+- `app.json` provides non-secret application metadata.
+- `bin/post_compile` prepares and verifies project-local TextBlob/NLTK data.
+
+Packaging-only changes must not edit `app.py`, `bot.py`, `slack.py`,
+`slack_auth.py`, `slack_replay.py`, `settings.py`, `config.py`, or `views/`.
+Changes to routes, environment-variable meaning, authentication, moderation,
+responses, request limits, retry behavior, or provider API calls are behavior
+changes and require their own focused PR and tests.
+
+## Configuration Boundary
+
+Deployment secrets remain provider configuration and do not belong in
+`app.json`, the `Procfile`, source files, logs, or screenshots. Configure
+`SLACK_SIGNING_SECRET`, `MESSENGER_TOKEN`, `MESSENGER_VERIFY_TOKEN`, and
+`MESSENGER_APP_SECRET` through the provider's secret store. `REQUEST_TIMEOUT`
+is optional and `PORT` is supplied by the runtime.
+
+`bin/post_compile` may download the TextBlob `lite` corpora during deployment.
+It writes only to the repository's `nltk_data` directory and uses the provider's
+selected Python interpreter.
+
+## Validation
+
+From an activated supported virtual environment, packaging changes must run:
+
+```bash
+python -m json.tool app.json >/dev/null
+bash -n bin/post_compile
+make check PYTHON="$(command -v python)"
+```
+
+Review the `Procfile` command and `.python-version` as text because starting a
+real provider dyno is outside the offline gate. Dependency updates must also
+retain exact pins and pass the hosted Python 3.10, 3.12, and 3.14 matrix before
+merge.
+
+## Change And Rollback Discipline
+
+Keep packaging changes in a dedicated PR. Record the previous Python line,
+dependency pins, start command, or post-compile behavior in the PR so rollback
+is a direct revert. Do not combine a packaging rollback with bot behavior
+changes; restore packaging first, then diagnose behavior separately.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This README is based on the checked-in source, manifests, scripts, and repositor
 - `docs` - source or example code
 - `nltk_data` - source or example code
 - `Procfile`
+- [`DEPLOYMENT.md`](DEPLOYMENT.md) - deployment packaging ownership and validation
 - `SECURITY.md` - security reporting and disclosure guidance
 - `VISION.md` - project direction and maintenance guardrails
 
@@ -68,6 +69,8 @@ reviewed project-local corpus directory.
 
 - Run `python app.py` after installing Python dependencies. Bottle debug mode
   remains off unless `BOTTLE_DEBUG=true` is explicitly set for local work.
+- Keep provider packaging changes within the file ownership and validation
+  boundary documented in [`DEPLOYMENT.md`](DEPLOYMENT.md).
 
 ## Testing and Verification
 

--- a/VISION.md
+++ b/VISION.md
@@ -56,7 +56,8 @@ Priority:
 
 Next priorities:
 
-- Separate deployment packaging from bot behavior changes
+- No unclaimed roadmap item; select future work from reproduced defects,
+  dependency advisories, or reviewed integration needs.
 
 Contribution rules:
 

--- a/docs/plans/2026-06-25-deployment-packaging-boundary.md
+++ b/docs/plans/2026-06-25-deployment-packaging-boundary.md
@@ -1,0 +1,37 @@
+# Deployment Packaging Boundary
+
+status: completed
+
+## Context
+
+Valleybot's deployment files were individually inspectable, but the repository
+did not state which changes are packaging-only or when a change crosses into
+routes, authentication, moderation, response generation, or provider behavior.
+
+## Requirements
+
+- Inventory every deployment packaging file and its responsibility.
+- Keep secrets in provider configuration rather than repository packaging.
+- Identify behavior-owned files that packaging-only changes must not edit.
+- Document offline syntax, corpus, runtime, and hosted-matrix verification.
+- Keep packaging rollback independent from bot behavior rollback.
+- Remove the completed separation item from the roadmap.
+
+## Work Completed
+
+- Added `DEPLOYMENT.md` with packaging ownership, configuration, validation,
+  hosted evidence, and rollback boundaries.
+- Linked the guide from repository contents and local usage guidance.
+- Replaced the final roadmap item with an evidence-driven future-work rule.
+- Added a dependency-free documentation contract and changelog record.
+
+## Verification Completed
+
+- Reproduced the missing guide and plan as a failing dependency-free contract.
+- Ran the focused deployment packaging documentation contract.
+- Ran `python -m json.tool app.json` and `bash -n bin/post_compile`.
+- Ran `make check` with the documented Python 3.14 virtual environment.
+- Passed 77 dependency-free contracts, 43 Bottle/bot runtime tests, six Slack
+  replay mutations, five web-chat length mutations, corpus verification, and
+  the 40-case Make authority matrix.
+- Confirmed `git diff --check` passes.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -116,6 +116,9 @@ MAKE_AUTHORITY_PLAN_PATH = (
 PYTHON_NLTK_SETUP_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-25-python-nltk-setup.md"
 )
+DEPLOYMENT_PACKAGING_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-25-deployment-packaging-boundary.md"
+)
 
 
 class FakeBottle:
@@ -396,6 +399,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(NLTK_RESOURCE_GUARD_PLAN_PATH, "NLTK resource path guard")
     assert_completed_plan(MAKE_AUTHORITY_PLAN_PATH, "Make authority isolation")
     assert_completed_plan(PYTHON_NLTK_SETUP_PLAN_PATH, "Python and NLTK setup")
+    assert_completed_plan(DEPLOYMENT_PACKAGING_PLAN_PATH, "deployment packaging boundary")
     registered = registered_main_tests(
         (ROOT / "scripts" / "check_valleybot_contracts.py").read_text(encoding="utf-8")
     )
@@ -729,6 +733,37 @@ def test_python_nltk_setup_documentation_contract():
     assert_true(
         "same-interpreter Python and NLTK setup" in changes,
         "CHANGES must record the Python and NLTK setup contract",
+    )
+
+
+def test_deployment_packaging_documentation_contract():
+    deployment = (ROOT / "DEPLOYMENT.md").read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    vision = (ROOT / "VISION.md").read_text(encoding="utf-8")
+    changes = (ROOT / "CHANGES.md").read_text(encoding="utf-8")
+    for contract in (
+            ".python-version",
+            "requirements.txt",
+            "Procfile",
+            "app.json",
+            "bin/post_compile",
+            "Packaging-only changes must not edit",
+            "python -m json.tool app.json",
+            "bash -n bin/post_compile",
+            'make check PYTHON="$(command -v python)"',
+            "Deployment secrets remain provider configuration"):
+        assert_true(contract in deployment, "DEPLOYMENT must retain {0}".format(contract))
+    assert_true(
+        "[`DEPLOYMENT.md`](DEPLOYMENT.md)" in readme,
+        "README must link the deployment boundary guide",
+    )
+    assert_true(
+        "Separate deployment packaging from bot behavior changes" not in vision,
+        "VISION must remove the completed deployment packaging priority",
+    )
+    assert_true(
+        "deployment packaging boundary" in changes,
+        "CHANGES must record the deployment packaging boundary",
     )
 
 
@@ -2145,6 +2180,7 @@ def main():
         test_shell_entrypoints_use_portable_cdpath_reset,
         test_prepare_corpora_uses_project_local_nltk_data_contract,
         test_python_nltk_setup_documentation_contract,
+        test_deployment_packaging_documentation_contract,
         test_messenger_post_rejects_oversized_declared_body,
         test_messenger_post_rejects_oversized_streamed_body,
         test_messenger_post_rejects_invalid_signature,


### PR DESCRIPTION
## Summary
- define the five deployment-packaging-owned files and their responsibilities
- keep routes, authentication, moderation, responses, limits, retries, and provider behavior outside packaging-only changes

## Baseline
- deployment packaging lacked an explicit ownership boundary, secret model, verification path, and rollback discipline

## Improvements
- document provider-secret ownership, corpus preparation, offline checks, hosted evidence, and rollback, then close the final explicit roadmap item with a dependency-free contract and completed plan

## Validation
- focused deployment contract failed before the guide and plan existed, then passed
- `python -m json.tool app.json`
- `bash -n bin/post_compile`
- `make check` passed 77 dependency-free contracts, 43 runtime tests, 11 hostile mutations, and the 40-case Make authority matrix
- `git diff --check`

## Risk
- deployment provider behavior and production secret injection remain outside local packaging-contract validation

## Follow-Ups
- keep application behavior changes separate from the five packaging-owned files
