### PR TITLE
Fix Messenger replay-heavy batch starvation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@
   enter the bounded replay cache, and failures release claims for retry.
 - In-flight Messenger message-ID claims are never capacity-evicted; only
   completed claims enter the bounded replay cache.
+- Replayed Messenger message IDs do not consume the bounded per-webhook work
+  limit; count only acquired claims and ID-less messages.
 - Preserve punctuation and non-space whitespace token boundaries in the final
   response filter; changes to moderation text still require human review.
 - Keep Slack and Messenger message text within the shared channel limit before

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,56 @@
 # Changes
 
+## 2026-06-26T20:50:03-07:00 — P1 correctness/availability — cycle: Messenger replay-heavy batch cap
+
+### Summary
+
+Messenger now applies its 20-message webhook limit only to events that acquire
+replay ownership or have no message ID. Completed replay IDs are skipped without
+consuming work capacity, so they cannot hide a later unique event in the same
+signed batch.
+
+### Work completed
+
+- Converted Messenger event extraction from a capped intermediate list to a
+  lazy payload-order iterator.
+- Moved the work cap into the webhook handler and checked it before claiming the
+  next unique event.
+- Counted work only after a replay claim succeeds, while preserving ID-less
+  compatibility, reply ordering, completion, and failure release.
+- Added dependency-free and Bottle/WebTest regressions for 20 completed replay
+  IDs followed by one unique event.
+- Updated security, contributor, roadmap, and implementation-plan evidence.
+
+### Files
+
+- `app.py` — lazy Messenger parsing and owned-work accounting.
+- `bot_tests.py`, `scripts/check_valleybot_contracts.py` — runtime, dependency-free,
+  and source-order contracts.
+- `AGENTS.md`, `README.md`, `SECURITY.md`, `VISION.md` — documented replay and
+  batch-limit semantics.
+- `docs/plans/2026-06-26-messenger-replay-batch-cap.md` — implementation plan.
+
+### Tests
+
+- Focused dependency-free replay-heavy batch regression: passed after reproducing
+  the prior zero-reply failure.
+- `make check PYTHON=/tmp/valleybot-20260626-venv/bin/python`: passed with 82
+  dependency-free contracts, 6 rejected Slack replay mutations, 5 rejected web
+  chat length mutations, and 46 Bottle/WebTest runtime tests on Python 3.14.6.
+- `git diff --check`: passed.
+
+### Findings and blockers
+
+- Bug fixed: the parser previously spent the complete 20-message budget before
+  the handler checked replay ownership.
+- Replay state remains process-local and does not coordinate across workers or
+  process restarts.
+
+### Next action
+
+- Publish the exact reviewed head and merge only after hosted Python and CodeQL
+  checks pass.
+
 ## 2026-06-26T12:19:26Z — P1 resilience — cycle: channel message length boundary
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ reviewed project-local corpus directory.
   cache so provider retries do not send duplicate replies; outbound exceptions
   release their claim for recovery. Unsuccessful provider HTTP responses raise
   before reply content is accepted, allowing the webhook delivery to be
-  retried. Signed webhook batches process up to 20 valid user messages in
-  payload order. Unknown top-level Messenger fields cannot suppress valid replies.
+  retried. Signed webhook batches process up to 20 owned user messages in
+  payload order; completed replay IDs are skipped without consuming that work
+  limit. Unknown top-level Messenger fields cannot suppress valid replies.
   Messenger POST bodies larger than 1 MiB are rejected with HTTP
   413 before signature verification or JSON parsing. Generated responses that
   fail moderation use a reviewed generic fallback instead of failing a request.
@@ -134,6 +135,8 @@ reviewed project-local corpus directory.
   process-local Messenger retry guard.
 - In-flight Messenger message-ID claims are never capacity-evicted; only
   completed claims enter the bounded replay cache.
+- Replayed Messenger message IDs do not consume the bounded per-webhook work
+  limit; count only acquired claims and ID-less messages.
 - See `docs/plans/2026-06-25-messenger-inflight-replay-claims.md` for the
   concurrent replay-claim lifecycle.
 - See `docs/plans/2026-06-13-messenger-batch-processing-bound.md` for ordered,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,9 +58,10 @@ workers or process restarts.
 In-flight Messenger message-ID claims are never capacity-evicted; only completed claims enter the bounded replay cache.
 Provider HTTP errors propagate through the webhook handler and release any
 message-ID claim so a later provider delivery can retry the outbound reply.
-Each signed webhook processes at most 20 valid user messages in payload order,
+Each signed webhook processes at most 20 owned user messages in payload order,
 limiting outbound reply amplification while preserving per-message replay
-claims and failure release.
+claims and failure release. Completed replay IDs do not consume that work
+limit, so retries cannot hide a later unique event in the same signed batch.
 Unknown top-level fields, including `debug`, do not suppress valid Messenger replies.
 Generated responses are tokenized across punctuation and non-space whitespace
 boundaries before blocked-prefix checks; this remains a narrow final-output

--- a/VISION.md
+++ b/VISION.md
@@ -29,7 +29,8 @@ Priority:
 - Suppress duplicate Messenger replies from retried message IDs with bounded
   process-local state
 - In-flight Messenger message-ID claims are never capacity-evicted; only completed claims enter the bounded replay cache.
-- Process Messenger message batches in order with a fixed per-webhook cap
+- Process Messenger message batches in order with a fixed per-webhook cap that
+  counts acquired claims and ID-less messages, not completed replay IDs
 - Keep Messenger reply behavior independent of client-controlled debug fields
 - Fail Messenger replies on provider HTTP errors so webhook retries remain
   recoverable

--- a/app.py
+++ b/app.py
@@ -161,14 +161,14 @@ def messenger_post():
         response.status = 400
         return "invalid payload"
 
-    messages = parse_messenger_messages(data)
-    if not messages:
-        return "ok"
-
     # send message to get bot
-    for sender, message, message_id in messages:
+    processed_messages = 0
+    for sender, message, message_id in parse_messenger_messages(data):
+        if processed_messages >= MAX_MESSENGER_MESSAGES_PER_WEBHOOK:
+            break
         if message_id and not recent_messenger_message_ids.claim(message_id):
             continue
+        processed_messages += 1
         try:
             messenger_reply(sender, message)
             if message_id:
@@ -243,13 +243,12 @@ def clean_text_value(value):
 
 def parse_messenger_messages(data):
     """
-    Return a bounded list of sender/text/message-ID tuples in payload order.
+    Yield sender/text/message-ID tuples in payload order.
     """
     entries = data.get('entry')
     if not isinstance(entries, list):
-        return []
+        return
 
-    messages = []
     for entry in entries:
         if not isinstance(entry, dict):
             continue
@@ -279,11 +278,7 @@ def parse_messenger_messages(data):
                 message_id = None
             if (sender_id and message_text and
                     len(message_text) <= MAX_CHANNEL_MESSAGE_CHARACTERS):
-                messages.append((sender_id, message_text, message_id or None))
-                if len(messages) >= MAX_MESSENGER_MESSAGES_PER_WEBHOOK:
-                    return messages
-
-    return messages
+                yield sender_id, message_text, message_id or None
 
 
 def messenger_reply(user_id, msg):

--- a/bot_tests.py
+++ b/bot_tests.py
@@ -597,6 +597,34 @@ class TestFacebook(unittest.TestCase):
         self.assertEqual(calls[0], ('user-0', 'message-0'))
         self.assertEqual(calls[-1], ('user-19', 'message-19'))
 
+    def test_facebook_replayed_ids_do_not_exhaust_batch_limit(self):
+        calls = []
+        original_reply = app.messenger_reply
+        app.messenger_reply = lambda sender, message: calls.append(
+            (sender, message))
+        events = []
+        for index in range(app.MAX_MESSENGER_MESSAGES_PER_WEBHOOK):
+            message_id = 'batch-replay-runtime-{0}'.format(index)
+            self.assertTrue(app.recent_messenger_message_ids.claim(message_id))
+            app.recent_messenger_message_ids.complete(message_id)
+            events.append({
+                'sender': {'id': 'replayed-{0}'.format(index)},
+                'message': {'text': 'replayed', 'mid': message_id},
+            })
+        events.append({
+            'sender': {'id': 'user-unique'},
+            'message': {'text': 'unique', 'mid': 'mid-batch-unique'},
+        })
+
+        try:
+            response = self.post_signed_json(
+                {'object': 'page', 'entry': [{'messaging': events}]})
+        finally:
+            app.messenger_reply = original_reply
+
+        self.assertEqual(response.status_int, 200)
+        self.assertEqual(calls, [('user-unique', 'unique')])
+
     def test_facebook_webhook_skips_oversized_message_and_continues(self):
         calls = []
         original_reply = app.messenger_reply

--- a/docs/plans/2026-06-26-messenger-replay-batch-cap.md
+++ b/docs/plans/2026-06-26-messenger-replay-batch-cap.md
@@ -1,0 +1,44 @@
+# Messenger Replay Batch Cap Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Ensure replayed Messenger IDs do not consume the 20-message work limit and hide later unique signed events.
+
+**Architecture:** Convert the nested Messenger parser into a lazy iterator. The webhook handler will stop after 20 messages that actually acquire replay ownership (or have no ID), while replayed IDs are skipped without consuming work capacity or building an unbounded intermediate list.
+
+**Tech Stack:** Python 3, Bottle/WebTest runtime tests, dependency-free request stubs, source/mutation contracts, GNU Make.
+
+---
+
+Status: Completed
+
+### Task 1: Reproduce replay starvation
+
+**Files:**
+- Modify: `bot_tests.py`
+- Modify: `scripts/check_valleybot_contracts.py`
+
+Add signed-batch tests with 20 already-completed IDs followed by one unique ID.
+Run the focused dependency-free test and observe that the unique recipient is not called.
+
+### Task 2: Count owned work lazily
+
+**Files:**
+- Modify: `app.py`
+
+Yield normalized events from `parse_messenger_messages`, move the cap into
+`messenger_post`, and increment only after a unique claim succeeds or for an
+ID-less message. Check the limit before claiming the next work item.
+
+### Task 3: Preserve contracts and evidence
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `CHANGES.md`
+- Modify: `README.md`
+- Modify: `SECURITY.md`
+- Modify: `VISION.md`
+- Modify: `scripts/check_valleybot_contracts.py`
+
+Run `make check` with the reviewed dependency environment, the replay mutation
+suite, Python/shell syntax checks, and `git diff --check` before publishing.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -1175,6 +1175,31 @@ def test_messenger_post_caps_valid_batch():
     )
 
 
+def test_messenger_post_replayed_ids_do_not_exhaust_batch_limit():
+    app, request, _response, requests = load_app()
+    events = []
+    for index in range(app.MAX_MESSENGER_MESSAGES_PER_WEBHOOK):
+        message_id = "mid-batch-replay-{0}".format(index)
+        assert_true(
+            app.recent_messenger_message_ids.claim(message_id),
+            "seed completed Messenger replay claim",
+        )
+        app.recent_messenger_message_ids.complete(message_id)
+        events.append(messenger_event(
+            "replayed-{0}".format(index), "replayed", message_id))
+    events.append(messenger_event(
+        "user-unique", "unique", "mid-batch-unique"))
+    request.json = messenger_batch_payload(events)
+
+    assert_equal(app.messenger_post(), "ok", "replay-heavy Messenger batch response")
+    assert_equal(len(requests.calls), 1, "replay-heavy Messenger batch reply count")
+    assert_equal(
+        requests.calls[0][1]["json"]["recipient"]["id"],
+        "user-unique",
+        "replay-heavy Messenger batch unique recipient",
+    )
+
+
 def test_messenger_post_skips_oversized_message_and_continues_batch():
     app, request, _response, requests = load_app()
     request.json = messenger_batch_payload([
@@ -1406,39 +1431,49 @@ def test_messenger_batch_source_contracts():
     runtime_tests = (ROOT / "bot_tests.py").read_text(encoding="utf-8")
     for contract in (
             "MAX_MESSENGER_MESSAGES_PER_WEBHOOK = 20",
-            "messages = parse_messenger_messages(data)",
-            "for sender, message, message_id in messages:",
+            "processed_messages = 0",
+            "for sender, message, message_id in parse_messenger_messages(data):",
+            "if processed_messages >= MAX_MESSENGER_MESSAGES_PER_WEBHOOK:",
+            "processed_messages += 1",
             "if not isinstance(sender, dict) or not isinstance(message, dict):",
-            "messages.append((sender_id, message_text, message_id or None))",
-            "if len(messages) >= MAX_MESSENGER_MESSAGES_PER_WEBHOOK:",
-            "return messages"):
+            "yield sender_id, message_text, message_id or None"):
         assert_true(contract in source, "missing Messenger batch contract {0}".format(contract))
     assert_true(
         "return sender_id, message_text, message_id or None" not in source,
         "Messenger parser must not regress to first-message return semantics",
     )
+    assert_true(
+        "messages.append((sender_id, message_text, message_id or None))" not in source,
+        "Messenger parser must not spend the work cap before replay claims",
+    )
     for test_name in (
             "test_facebook_webhook_replies_to_valid_messages_in_order",
-            "test_facebook_webhook_caps_valid_message_batch"):
+            "test_facebook_webhook_caps_valid_message_batch",
+            "test_facebook_replayed_ids_do_not_exhaust_batch_limit"):
         assert_true(test_name in runtime_tests, "missing Bottle/WebTest batch coverage {0}".format(test_name))
 
-    parse_position = source.index("messages = parse_messenger_messages(data)")
-    loop_position = source.index("for sender, message, message_id in messages:")
+    loop_position = source.index(
+        "for sender, message, message_id in parse_messenger_messages(data):")
+    limit_position = source.index(
+        "if processed_messages >= MAX_MESSENGER_MESSAGES_PER_WEBHOOK:",
+        loop_position,
+    )
     claim_position = source.index("recent_messenger_message_ids.claim(message_id)", loop_position)
+    count_position = source.index("processed_messages += 1", loop_position)
     reply_position = source.index("messenger_reply(sender, message)", loop_position)
     complete_position = source.index("recent_messenger_message_ids.complete(message_id)", loop_position)
     release_position = source.index("recent_messenger_message_ids.release(message_id)", loop_position)
     assert_true(
-        parse_position < loop_position < claim_position < reply_position <
+        loop_position < limit_position < claim_position < count_position < reply_position <
         complete_position < release_position,
-        "bounded extraction and per-message claim, reply, completion, and release must stay ordered",
+        "work limit, claim, count, reply, completion, and release must stay ordered",
     )
 
     docs = {
-        "README.md": "Signed webhook batches process up to 20",
-        "SECURITY.md": "Each signed webhook processes at most 20",
-        "VISION.md": "Process Messenger message batches in order",
-        "CHANGES.md": "Processed up to 20 valid Messenger user messages",
+        "README.md": "Replayed Messenger message IDs do not consume",
+        "SECURITY.md": "Completed replay IDs do not consume that work",
+        "VISION.md": "counts acquired claims and ID-less messages",
+        "CHANGES.md": "Completed replay IDs are skipped without",
     }
     for relative_path, phrase in docs.items():
         assert_true(
@@ -2301,6 +2336,7 @@ def main():
         test_messenger_post_rejects_non_page_object,
         test_messenger_post_processes_valid_batch_in_payload_order,
         test_messenger_post_caps_valid_batch,
+        test_messenger_post_replayed_ids_do_not_exhaust_batch_limit,
         test_messenger_post_skips_oversized_message_and_continues_batch,
         test_messenger_post_applies_replay_claims_per_batch_message,
         test_messenger_post_debug_field_does_not_suppress_replies,


### PR DESCRIPTION
## Summary
- parse Messenger events lazily in payload order
- count the 20-message cap only after replay ownership succeeds, or for ID-less events
- cover replay-heavy batches with dependency-free and Bottle/WebTest regressions

## Verification
- `make check PYTHON=/tmp/valleybot-20260626-venv/bin/python`
- `git diff --check`

## Risk
Replay state remains process-local, matching the existing documented boundary.
