### PR TITLE
Observe that make check reaches and gates on every runner

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,6 +37,14 @@ jobs:
         run: /usr/bin/make check PYTHON="$(command -v python)"
       - name: Verify external working directory
         run: cd "$(mktemp -d)" && /usr/bin/make -C "$GITHUB_WORKSPACE" check PYTHON="$(command -v python)"
+      # Independent of `make check`: if the check -> verify -> root-test/test
+      # prerequisite chain is ever severed, `make check` goes green while running
+      # nothing. These two steps invoke the gate observer and the contract
+      # checker directly, so a fully disconnected gate is still caught here.
+      - name: Verify the gate observer independently of make
+        run: /bin/sh scripts/test-makefile-root.sh
+      - name: Verify repository contracts independently of make
+        run: REPOSITORY_PYTHON="$(command -v python)" scripts/run-python.sh scripts/check_valleybot_contracts.py
 
   codeql:
     name: CodeQL (${{ matrix.language }})

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,29 @@
 # Changes
 
+## 2026-07-17T00:00:00-07:00 — P1 verification gap — cycle: Gate runner execution observation
+
+### Summary
+
+`make check` now observes that every reviewed gate runner executes and that its
+verdict fails the build. Previously the gate asserted that runner source text
+existed but never that the runners ran or gated: `|| true` or a `-` prefix on a
+runner invocation let the checker print `AssertionError` while `make check`
+exited 0, deleting an invocation removed a mutation control silently, and
+`check:: clean` dropped the entire gate with a green exit.
+
+### Work completed
+
+- Added 7 out-of-band failure-injection cases to `scripts/test-makefile-root.sh`
+  that assert each runner is both reached and gated on, with a negative control.
+- Made `root-test` a direct prerequisite of `check` so the observer cannot be
+  disconnected by severing `check -> verify`.
+- Pinned the prerequisite chain and all six runner invocation lines whole-line,
+  and rejected `-` prefixes, `|| true`-style neuters, and CI `continue-on-error`.
+- Added two make-independent CI steps that invoke the gate observer and the
+  contract checker directly.
+
+See `docs/plans/2026-07-17-gate-runner-execution-observation.md`.
+
 ## 2026-06-26T20:50:03-07:00 — P1 correctness/availability — cycle: Messenger replay-heavy batch cap
 
 ### Summary

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ root-test::
 
 verify:: root-test lint test build
 
-check:: clean verify
+check:: clean root-test verify
 	/usr/bin/find '$(REPOSITORY_ROOT_LITERAL)' -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
 	/usr/bin/find '$(REPOSITORY_ROOT_LITERAL)' -type d -name '__pycache__' -prune -exec /bin/rm -rf {} +
 endef

--- a/docs/plans/2026-07-17-gate-runner-execution-observation.md
+++ b/docs/plans/2026-07-17-gate-runner-execution-observation.md
@@ -1,0 +1,70 @@
+# Gate Runner Execution Observation
+
+Status: Completed
+
+## Problem
+
+Every repository gate ran from `make check`, but nothing observed that the
+runners actually *executed* or that their verdicts actually *failed the build*.
+The Makefile's authority hardening was thorough about *who may invoke make* and
+*with what interpreter*, and `scripts/check_valleybot_contracts.py` pinned the
+Makefile's authority lines whole-line. Coverage stopped one line short of the
+recipe lines that invoke the gate runners themselves:
+
+- `check:: clean verify` was not pinned at all, so `check:: clean` silently
+  dropped `root-test`, `lint`, `test`, and `build`.
+- The four `test::` runner invocation lines were not pinned as whole lines. The
+  only pins were substrings such as `"scripts/test_slack_replay_mutations.py" in
+  makefile`, which the `PYTHON_FILES` lint list already satisfies on its own, so
+  the pin stayed green with the invocation deleted.
+- No pin rejected `|| true` or a `-` recipe prefix on a runner line.
+- Nothing rejected `continue-on-error` in the CI workflow.
+
+`scripts/test-makefile-root.sh` did observe execution, but its fake interpreter
+always exited 0, so it could not see a swallowed verdict.
+
+Measured before this change (`make check` exit status):
+
+| Mutation | Runner verdict | `make check` |
+| --- | --- | --- |
+| `|| true` on the contracts invocation | `AssertionError` printed | 0 |
+| `-` prefix on the contracts invocation | `Error 1 (ignored)` | 0 |
+| Delete the web-chat-length invocation | never ran | 0 |
+| Delete the replay-mutation + `bot_tests.py` invocations | never ran | 0 |
+| `check:: clean verify` -> `check:: clean` | nothing ran | 0 |
+
+## Scope
+
+- Observe execution *and* gating out-of-band, rather than asserting source text.
+- Keep the observer outside the blast radius of what it detects.
+- Preserve the existing Make authority boundary and all 40 authority cases.
+
+## Work completed
+
+- `scripts/test-makefile-root.sh`: the fake interpreter now fails on demand via
+  `VALLEYBOT_FAIL_MATCH`, and 7 failure-injection cases run the real Makefile
+  out-of-band, injecting a non-zero exit into exactly one runner at a time. Each
+  case asserts both that `make check` *reached* the runner and that its failure
+  *propagated*, plus a no-injection negative control so the assertions cannot be
+  satisfied by an unconditionally red gate.
+- `Makefile`: `root-test` became a direct prerequisite of `check`
+  (`check:: clean root-test verify`), so severing `check -> verify` can no longer
+  disconnect the observer along with everything else.
+- `scripts/check_valleybot_contracts.py`: pins the prerequisite chain and all six
+  runner invocation lines whole-line with exact occurrence counts, rejects `-`
+  prefixes and `|| true`-style neuters on every recipe line, rejects
+  `continue-on-error` in CI, and cross-guards the observer's own contract
+  phrases. Both new tests are registration-guarded in `main()`.
+- `.github/workflows/check.yml`: two make-independent steps invoke the gate
+  observer and the contract checker directly, so a fully disconnected gate is
+  still caught from outside the disconnected path.
+
+## Verification
+
+The repository and external-directory `make check` passed. Each mutation in the
+table above now fails; the mutual cross-guard and the direct CI observers were
+each exercised by hand. The one residual limit is recorded honestly: `make check`
+alone cannot detect its own total disconnection (`check:: clean` with every
+prerequisite removed) — an observer cannot observe its own removal — but both
+direct CI steps go red on it, which is the boundary the CI workflow exists to
+cover.

--- a/scripts/check_valleybot_contracts.py
+++ b/scripts/check_valleybot_contracts.py
@@ -407,10 +407,14 @@ def test_completed_plans_are_in_docs_plans():
     registered = registered_main_tests(
         (ROOT / "scripts" / "check_valleybot_contracts.py").read_text(encoding="utf-8")
     )
-    assert_true(
-        "test_slack_replay_source_contracts" in registered,
-        "Slack replay source contracts must remain registered",
-    )
+    for required in (
+            "test_slack_replay_source_contracts",
+            "test_make_gate_runner_execution_is_observed",
+            "test_ci_runs_the_gate_without_error_suppression"):
+        assert_true(
+            required in registered,
+            "{0} must remain registered in main()".format(required),
+        )
 
 
 def test_runtime_and_ci_contracts():
@@ -601,6 +605,112 @@ def test_make_authority_boundary_is_truthful():
         "4 raw Make-syntax controls with the GNU Make 4.4 command-root pre-load boundary",
     ):
         assert_true(contract in authority_test, "Make authority harness must include {0}".format(contract))
+
+
+def test_make_gate_runner_execution_is_observed():
+    """The gate must reach, and gate on, every reviewed runner.
+
+    `make check` delegates entirely to prerequisites, so a source-text pin on a
+    runner's own contents proves nothing about whether the runner still runs or
+    whether its verdict still fails the build. Four independent neuters are
+    invisible to a substring pin: `|| true`, a `-` recipe prefix, deleting the
+    invocation line outright, and severing the `check` -> `verify` chain. This
+    test pins the chain and the exact invocation lines; the execution and
+    gating properties themselves are observed out-of-band by
+    scripts/test-makefile-root.sh, which is cross-guarded below.
+    """
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    makefile_lines = makefile.splitlines()
+    line_set = set(makefile_lines)
+
+    for contract in (
+            "check:: clean root-test verify",
+            "verify:: root-test lint test build",
+            "test:: prepare-corpora",
+            "build:: lint",
+            "root-test::"):
+        assert_true(
+            contract in line_set,
+            "make check prerequisite chain must keep {0!r}".format(contract),
+        )
+
+    runner_prefix = "\tREPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' "
+    launcher = "'$(REPOSITORY_ROOT_LITERAL)/scripts/run-python.sh' "
+    for runner_line in (
+            "\t/bin/sh '$(REPOSITORY_ROOT_LITERAL)/scripts/test-makefile-root.sh'",
+            runner_prefix + "'$(REPOSITORY_ROOT_LITERAL)/scripts/prepare_nltk_data.sh'",
+            runner_prefix + launcher
+            + "'$(REPOSITORY_ROOT_LITERAL)/scripts/check_valleybot_contracts.py'",
+            runner_prefix + launcher
+            + "'$(REPOSITORY_ROOT_LITERAL)/scripts/test_slack_replay_mutations.py'",
+            runner_prefix + launcher
+            + "'$(REPOSITORY_ROOT_LITERAL)/scripts/test_web_chat_length_contract.py'",
+            "\tcd '$(REPOSITORY_ROOT_LITERAL)' && /usr/bin/env "
+            "SLACK_SIGNING_SECRET=test-slack-signing-secret "
+            "MESSENGER_TOKEN=test-page-token "
+            "MESSENGER_VERIFY_TOKEN=test-verify-token "
+            "REPOSITORY_PYTHON='$(REPOSITORY_PYTHON_LITERAL)' "
+            + launcher + "'$(REPOSITORY_ROOT_LITERAL)/bot_tests.py'"):
+        assert_equal(
+            makefile_lines.count(runner_line),
+            1,
+            "exactly one un-neutered gate invocation of {0!r}".format(runner_line),
+        )
+
+    for index, line in enumerate(makefile_lines, start=1):
+        if not line.startswith("\t"):
+            continue
+        recipe = line[1:]
+        while recipe[:1] in ("@", "+"):
+            recipe = recipe[1:]
+        assert_true(
+            not recipe.startswith("-"),
+            "Makefile recipe line {0} must not ignore errors with a '-' prefix".format(index),
+        )
+        for neuter in ("|| true", "|| :", "|| exit 0", "|| /bin/true", "; true", "set +e"):
+            assert_true(
+                neuter not in recipe,
+                "Makefile recipe line {0} must not discard a failure with {1!r}".format(
+                    index, neuter
+                ),
+            )
+
+    authority_test = (ROOT / "scripts" / "test-makefile-root.sh").read_text(encoding="utf-8")
+    for contract in (
+            "VALLEYBOT_FAIL_MATCH",
+            "make check never invoked the runner matching:",
+            "make check swallowed a failing runner matching:",
+            "make check ignored errors from the runner matching:",
+            '[ "$injected" -eq 7 ]',
+            "7 runner failure-injection cases"):
+        assert_true(
+            contract in authority_test,
+            "Make authority harness must keep observing runner gating: {0!r}".format(contract),
+        )
+
+
+def test_ci_runs_the_gate_without_error_suppression():
+    workflow = CI_WORKFLOW_PATH.read_text(encoding="utf-8")
+    workflow_lines = workflow.splitlines()
+    assert_true(
+        "continue-on-error" not in workflow,
+        "CI must not let a failing gate step continue on error",
+    )
+    for step in (
+            '        run: /usr/bin/make check PYTHON="$(command -v python)"',
+            '        run: cd "$(mktemp -d)" && /usr/bin/make -C "$GITHUB_WORKSPACE" '
+            'check PYTHON="$(command -v python)"',
+            # Two make-independent observers: a severed check/verify chain makes
+            # `make check` vacuously green, so CI must also reach the gate
+            # observer and this checker without going through make.
+            '        run: /bin/sh scripts/test-makefile-root.sh',
+            '        run: REPOSITORY_PYTHON="$(command -v python)" '
+            'scripts/run-python.sh scripts/check_valleybot_contracts.py'):
+        assert_equal(
+            workflow_lines.count(step),
+            1,
+            "CI must invoke the gate directly: {0!r}".format(step),
+        )
 
 
 def test_nltk_resource_path_guard_contracts():
@@ -2312,6 +2422,8 @@ def main():
         test_completed_plans_are_in_docs_plans,
         test_runtime_and_ci_contracts,
         test_make_authority_boundary_is_truthful,
+        test_make_gate_runner_execution_is_observed,
+        test_ci_runs_the_gate_without_error_suppression,
         test_nltk_resource_path_guard_contracts,
         test_shell_entrypoints_use_portable_cdpath_reset,
         test_prepare_corpora_uses_project_local_nltk_data_contract,

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -32,6 +32,15 @@ FAKE_PYTHON="$TEMP_ROOT/trusted python's \"quoted\" \`touch VALLEYBOT_PYTHON_MAR
 cat >"$FAKE_PYTHON" <<'EOF'
 #!/bin/sh
 printf '%s|%s|%s\n' "$PWD" "$0" "$*" >> "$VALLEYBOT_COMMAND_LOG"
+if [ -n "${VALLEYBOT_FAIL_MATCH:-}" ]; then
+    case "$0 $*" in
+        *"$VALLEYBOT_FAIL_MATCH"*)
+            printf 'PLANTED RUNNER FAILURE: %s\n' "$VALLEYBOT_FAIL_MATCH" >&2
+            exit 9
+            ;;
+    esac
+fi
+exit 0
 EOF
 chmod +x "$FAKE_PYTHON"
 
@@ -100,6 +109,54 @@ for target in build check clean lint prepare-corpora root-test test verify; do
     done
 done
 [ "$executed" -eq 40 ]
+
+# `make check` must both REACH every reviewed gate runner and PROPAGATE its
+# failure. A source-text pin cannot see either property: `|| true`, a `-` recipe
+# prefix, a deleted invocation line, or a severed `check`/`verify` prerequisite
+# all leave the remaining pinned lines byte-identical. This observer runs the
+# real Makefile out-of-band and injects a non-zero exit into exactly one runner
+# at a time, so it sees the verdict rather than the text.
+inject_failure() {
+    match=$1
+    : >"$LOG"
+    set +e
+    (cd "$CONTROL_DIR" && VALLEYBOT_COMMAND_LOG="$LOG" VALLEYBOT_FAIL_MATCH="$match" \
+        make_run -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" check) >"$TEMP_ROOT/inject.out" 2>&1
+    status=$?
+    set -e
+    if ! grep -F -q -e "$match" "$LOG"; then
+        printf '%s\n' "make check never invoked the runner matching: $match" >&2
+        exit 1
+    fi
+    if [ "$status" -eq 0 ]; then
+        printf '%s\n' "make check swallowed a failing runner matching: $match" >&2
+        exit 1
+    fi
+    if grep -Fq '(ignored)' "$TEMP_ROOT/inject.out"; then
+        printf '%s\n' "make check ignored errors from the runner matching: $match" >&2
+        exit 1
+    fi
+}
+
+injected=0
+for match in \
+    "$CHECKOUT/scripts/test-makefile-root.sh" \
+    "$CHECKOUT/scripts/prepare_nltk_data.sh" \
+    "$CHECKOUT/scripts/check_valleybot_contracts.py" \
+    "$CHECKOUT/scripts/test_slack_replay_mutations.py" \
+    "$CHECKOUT/scripts/test_web_chat_length_contract.py" \
+    "$CHECKOUT/bot_tests.py" \
+    "-m py_compile"; do
+    inject_failure "$match"
+    injected=$((injected + 1))
+done
+[ "$injected" -eq 7 ]
+
+# Negative control: with nothing injected the same invocation must pass, so the
+# assertions above cannot be satisfied by an unconditionally red gate.
+: >"$LOG"
+(cd "$CONTROL_DIR" && VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" check) >"$TEMP_ROOT/inject-control.out" 2>&1
+grep -F -q -e "$CHECKOUT/scripts/check_valleybot_contracts.py" "$LOG"
 
 rm -f "$LOG"
 (cd "$CONTROL_DIR" && VALLEYBOT_COMMAND_LOG="$LOG" make_run -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" check) >/dev/null 2>&1
@@ -208,4 +265,4 @@ for flag in -n --just-print --dry-run --recon -t --touch -q --question -i --igno
     grep -Fq 'non-executing or error-ignoring MAKEFLAGS are not supported' "$TEMP_ROOT/flag"
 done
 
-printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python path, 4 raw Make-syntax controls with the GNU Make 4.4 command-root pre-load boundary, MAKEFILE_LIST command rejection and safe environment neutralization, 2 startup-boundary cases, cleanup containment, global override shell rejection, PATH-Python rejection, isolated Python startup, caller MAKEFLAGS rejection, and 10 unsafe mode rejections'
+printf '%s\n' 'Make authority tests passed: 40 target/authority cases, 7 runner failure-injection cases proving make check reaches and gates on every reviewed runner, literal hostile Python path, 4 raw Make-syntax controls with the GNU Make 4.4 command-root pre-load boundary, MAKEFILE_LIST command rejection and safe environment neutralization, 2 startup-boundary cases, cleanup containment, global override shell rejection, PATH-Python rejection, isolated Python startup, caller MAKEFLAGS rejection, and 10 unsafe mode rejections'


### PR DESCRIPTION
## The gap

Every gate in this repo runs from `make check`, and the Makefile's authority hardening is genuinely strong — 40 authority cases, hostile-path controls, MAKEFLAGS/MAKEFILES/SHELL rejection, `::` rules that make the recipe-override attack structurally impotent. But the gate **asserted that runner source text existed** and never asserted that the runners **executed** or that their verdicts **failed the build**.

`scripts/test-makefile-root.sh` does observe execution — but its fake interpreter always exited 0, so it could not see a swallowed verdict. And the runner invocation lines had only substring pins.

## Mutation evidence, both directions

All measured on a clean tree with a green baseline (82+6+5+46 tests, `make check` exit 0). Deps reached the `-I` recipes via a venv interpreter passed as `PYTHON=`.

| Mutation | Runner verdict | `make check` before | after |
| --- | --- | --- | --- |
| *(none — clean tree)* | all pass | **0** | **0** |
| `\|\| true` on the contracts invocation | prints `AssertionError: CHANGES.md must record challenge escaping` | **0** | **2** |
| `-` prefix on the contracts invocation | `make: [test] Error 1 (ignored)` | **0** | **2** |
| Delete the web-chat-length invocation | 5-mutation control never runs | **0** | **2** |
| Delete the replay-mutation + `bot_tests.py` invocations | 6-mutation control + all 46 runtime tests never run | **0** | **2** |
| `check:: clean verify` → `check:: clean` | root-test, lint, test, build all dropped | **0** | **0** (caught by CI, see below) |
| Drop only `verify` from `check` | runners never run | — | **2** |
| Drop `root-test` from both `check` and `verify` | observer never runs | — | **2** |
| `continue-on-error: true` on the CI gate step | — | **0** | **2** |
| Remove a direct CI observer step | — | — | **2** |
| Gut the observer's `[ "$injected" -eq 7 ]` counter | — | — | **2** |
| Unregister a new test from `main()` | — | — | **2** |

Two findings worth calling out:

- **The substring pin was self-satisfying.** `"scripts/test_slack_replay_mutations.py" in makefile` is satisfied by the `PYTHON_FILES` **lint list**, which still contains that path after the invocation line is deleted. The pin stayed green with the runner disconnected.
- **`check::`'s dependency on `verify` was unpinned.** `.DEFAULT_GOAL := check` and `verify:: root-test lint test build` were both whole-line pinned; the link between them was not. One edit dropped the whole gate.

## The fix

Observe the verdict, don't pin the text:

- **`scripts/test-makefile-root.sh`** — the fake interpreter now fails on demand via `VALLEYBOT_FAIL_MATCH`. 7 failure-injection cases run the real Makefile out-of-band, injecting a non-zero exit into exactly one runner at a time, asserting **both** that `make check` *reached* that runner (catches deletion and a severed chain) **and** that its failure *propagated* (catches `|| true`, `-`, ignored errors). A no-injection negative control prevents the assertions from being satisfied by an unconditionally red gate.
- **`Makefile`** — `root-test` is now a **direct** prerequisite of `check`. This is the important one: my first attempt hung both detectors off `verify`, so severing `check → verify` disconnected the detectors along with everything it was supposed to detect.
- **`scripts/check_valleybot_contracts.py`** — whole-line pins with exact occurrence counts on the prerequisite chain and all six runner invocations; rejects `-` prefixes and `|| true`-style neuters on every recipe line; rejects CI `continue-on-error`; cross-guards the observer's own contract phrases; both new tests are registration-guarded via the existing AST `registered_main_tests` mechanism.
- **`.github/workflows/check.yml`** — two make-independent steps invoke the gate observer and the contract checker **directly**.

The observer and the checker now **mutually cross-guard**: the contracts checker pins the `root-test` invocation line, and the observer sees the contracts line's verdict being swallowed. Because `root-test` runs before `test`, the observer fires **even when the contracts checker itself is neutered** — it is not inside its own blast radius.

## Honest residual limit

`check:: clean` with **every** prerequisite removed still leaves `make check` exit 0. An observer cannot observe its own removal. This is why the two direct CI steps exist: both go red on that mutation (observer exit 2, contracts exit 1 — `AssertionError: make check prerequisite chain must keep 'check:: clean root-test verify'`), which is detection from outside the disconnected path.

## Severity

**P1 verification gap, not a live defect.** No production behavior is wrong today — every underlying contract currently holds and the gate is green for real reasons. The severity is that four independent neuter tokens and two disconnection shapes could each land a real defect green, and the repo's mutation controls (the 6-mutation replay harness and the 5-mutation web-chat harness) could be silently disconnected while their pins stayed satisfied.

## Verification

Repository and external-directory `make check` both pass (exit 0): 40 authority cases + 7 injection cases, 84 contract tests, 6 + 5 mutations rejected, 46 runtime tests OK. Workflow YAML parses; both new steps present with no `continue-on-error`. Every mutation above was applied by hand with an asserted occurrence count and the mutated line echoed back, and reverted per-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
